### PR TITLE
Add optional semantic branch with semantic priors, projection heads, and losses

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,6 +58,19 @@ def get_parser():
     parser.add_argument('--transfer_loss_weight', type=float, default=1)
     parser.add_argument('--transfer_loss', type=str, default='mmd')
     parser.add_argument('--dis_loss_weight', type=float, default=1)
+
+    # semantic branch related
+    parser.add_argument('--use_semantic_branch', type=str2bool, default=False)
+    parser.add_argument('--semantic_path', type=str, default='')
+    parser.add_argument('--semantic_dim', type=int, default=0)
+    parser.add_argument('--shared_dim', type=int, default=128)
+    parser.add_argument('--semantic_hidden_dim', type=int, default=0)
+    parser.add_argument('--semantic_conf_threshold', type=float, default=0.9)
+    parser.add_argument('--semantic_metric', type=str, default='cosine')
+    parser.add_argument('--semantic_normalize', type=str2bool, default=True)
+    parser.add_argument('--semantic_loss_weight', type=float, default=1.0)
+    parser.add_argument('--semantic_src_weight', type=float, default=1.0)
+    parser.add_argument('--semantic_tgt_weight', type=float, default=1.0)
     return parser
 
 def set_random_seed(seed=0):
@@ -85,7 +98,23 @@ def load_data(args):
 
 def get_model(args):
     model = models.NewTransferNet(
-        args.n_class, transfer_loss=args.transfer_loss, base_net=args.backbone, max_iter=args.max_iter, input_channels=args.num_bands,use_bottleneck=args.use_bottleneck).to(args.device)
+        args.n_class,
+        transfer_loss=args.transfer_loss,
+        base_net=args.backbone,
+        max_iter=args.max_iter,
+        input_channels=args.num_bands,
+        use_bottleneck=args.use_bottleneck,
+        use_semantic_branch=args.use_semantic_branch,
+        semantic_path=args.semantic_path,
+        semantic_dim=args.semantic_dim,
+        shared_dim=args.shared_dim,
+        semantic_hidden_dim=args.semantic_hidden_dim,
+        semantic_conf_threshold=args.semantic_conf_threshold,
+        semantic_metric=args.semantic_metric,
+        semantic_normalize=args.semantic_normalize,
+        semantic_src_weight=args.semantic_src_weight,
+        semantic_tgt_weight=args.semantic_tgt_weight,
+    ).to(args.device)
     return model
 
 def get_optimizer(model, args):
@@ -169,7 +198,10 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
         train_loss_transfer = utils.AverageMeter()
         train_loss_dis = utils.AverageMeter()
         train_loss_total = utils.AverageMeter()
-        # train_loss_class = utils.AverageMeter()
+        train_loss_sem = utils.AverageMeter()
+        train_loss_sem_src = utils.AverageMeter()
+        train_loss_sem_tgt = utils.AverageMeter()
+        train_sem_valid_ratio = utils.AverageMeter()
         model.epoch_based_processing(n_batch)
 
         if max(len_target_loader, len_source_loader) != 0:
@@ -183,8 +215,11 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
                 args.device), label_source.to(args.device)
             data_target = data_target.to(args.device)
 
-            clf_loss, dis_loss, transfer_loss = model(data_source, data_target, label_source)
+            clf_loss, dis_loss, transfer_loss, semantic_metrics = model(data_source, data_target, label_source)
+            sem_loss = semantic_metrics['sem_loss']
             loss = clf_loss + args.transfer_loss_weight * transfer_loss + args.dis_loss_weight * dis_loss
+            if args.use_semantic_branch:
+                loss = loss + args.semantic_loss_weight * sem_loss
 
             optimizer.zero_grad()
             loss.backward()
@@ -196,12 +231,16 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
             train_loss_transfer.update(transfer_loss.item())
             train_loss_dis.update(dis_loss.item())
             # train_loss_class.update(class_loss.item())
+            train_loss_sem.update(sem_loss.item())
+            train_loss_sem_src.update(semantic_metrics['sem_src_loss'].item())
+            train_loss_sem_tgt.update(semantic_metrics['sem_tgt_loss'].item())
+            train_sem_valid_ratio.update(semantic_metrics['sem_valid_ratio'].item())
             train_loss_total.update(loss.item())
 
         log.append([train_loss_clf.avg, train_loss_transfer.avg, train_loss_total.avg])
 
-        info = 'Epoch: [{:2d}/{}], cls_loss: {:.4f}, transfer_loss: {:.4f}, dis_loss: {:.4f}, total_Loss: {:.4f}'.format(
-            e, args.n_epoch, train_loss_clf.avg, train_loss_transfer.avg, train_loss_dis.avg,train_loss_total.avg)
+        info = 'Epoch: [{:2d}/{}], cls_loss: {:.4f}, transfer_loss: {:.4f}, dis_loss: {:.4f}, sem_loss: {:.4f}, sem_src: {:.4f}, sem_tgt: {:.4f}, sem_ratio: {:.4f}, total_Loss: {:.4f}'.format(
+            e, args.n_epoch, train_loss_clf.avg, train_loss_transfer.avg, train_loss_dis.avg, train_loss_sem.avg, train_loss_sem_src.avg, train_loss_sem_tgt.avg, train_sem_valid_ratio.avg, train_loss_total.avg)
         # Test
         stop += 1
         test_acc, test_loss, per_class_acc, oa, aa, kappa, all_features, all_targets = test(model, target_test_loader, args)

--- a/models.py
+++ b/models.py
@@ -1,15 +1,41 @@
 import torch
 import torch.nn as nn
-from transfer_losses import TransferLoss
+
 import backbones
+from semantic_loader import load_semantic_embeddings
+from semantic_modules import ProjectionHead
+from semantic_losses import source_semantic_alignment_loss, target_semantic_consistency_loss
+from transfer_losses import TransferLoss
+
 
 class NewTransferNet(nn.Module):
-    def __init__(self, num_class, base_net='rsp_resnet50', transfer_loss='mmd', use_bottleneck=True, bottleneck_width=256, max_iter=1000, input_channels=3,**kwargs):
+    def __init__(
+        self,
+        num_class,
+        base_net='rsp_resnet50',
+        transfer_loss='mmd',
+        use_bottleneck=True,
+        bottleneck_width=256,
+        max_iter=1000,
+        input_channels=3,
+        use_semantic_branch=False,
+        semantic_path='',
+        semantic_dim=0,
+        shared_dim=128,
+        semantic_hidden_dim=0,
+        semantic_conf_threshold=0.9,
+        semantic_metric='cosine',
+        semantic_normalize=True,
+        semantic_src_weight=1.0,
+        semantic_tgt_weight=1.0,
+        **kwargs,
+    ):
         super(NewTransferNet, self).__init__()
         self.num_class = num_class
         self.base_network = backbones.get_backbone(base_net, input_channels=input_channels)
         self.use_bottleneck = use_bottleneck
         self.transfer_loss = transfer_loss
+
         if self.use_bottleneck:
             bottleneck_list = [
                 nn.Linear(self.base_network.output_num(), bottleneck_width),
@@ -21,20 +47,84 @@ class NewTransferNet(nn.Module):
             feature_dim = self.base_network.output_num()
 
         self.classifier_layer = nn.Linear(feature_dim, num_class)
+
         transfer_loss_args = {
-            "loss_type": self.transfer_loss,
-            "max_iter": max_iter,
-            "num_class": num_class
+            'loss_type': self.transfer_loss,
+            'max_iter': max_iter,
+            'num_class': num_class,
         }
         self.adapt_loss = TransferLoss(**transfer_loss_args)
         self.criterion = torch.nn.CrossEntropyLoss()
+
+        # Semantic branch
+        self.use_semantic_branch = use_semantic_branch
+        self.semantic_conf_threshold = semantic_conf_threshold
+        self.semantic_metric = semantic_metric
+        self.semantic_src_weight = semantic_src_weight
+        self.semantic_tgt_weight = semantic_tgt_weight
+
+        self.visual_projector = None
+        self.semantic_projector = None
+
+        if self.use_semantic_branch:
+            semantic_bank = load_semantic_embeddings(
+                semantic_path=semantic_path,
+                num_class=num_class,
+                normalize=semantic_normalize,
+            )
+            # allow optional explicit semantic_dim but keep compatibility if mismatch
+            if semantic_dim and semantic_dim > 0 and semantic_bank.shape[1] != semantic_dim:
+                raise ValueError(
+                    f'semantic_dim mismatch: expected {semantic_dim}, got {semantic_bank.shape[1]} from semantic bank'
+                )
+            semantic_dim = semantic_bank.shape[1]
+            self.register_buffer('semantic_bank', semantic_bank)
+
+            self.visual_projector = ProjectionHead(feature_dim, shared_dim, hidden_dim=semantic_hidden_dim)
+            self.semantic_projector = ProjectionHead(semantic_dim, shared_dim, hidden_dim=semantic_hidden_dim)
+
+    def _semantic_forward(self, source_feat, target_feat, source_label, target_clf):
+        zero = torch.tensor(0.0, device=source_feat.device)
+        metrics = {
+            'sem_loss': zero,
+            'sem_src_loss': zero,
+            'sem_tgt_loss': zero,
+            'sem_valid_ratio': zero,
+        }
+        if not self.use_semantic_branch:
+            return metrics
+
+        zv_source = self.visual_projector(source_feat)
+        zv_target = self.visual_projector(target_feat)
+        zs = self.semantic_projector(self.semantic_bank)
+
+        sem_src_loss = source_semantic_alignment_loss(
+            zv_source,
+            source_label,
+            zs,
+            metric=self.semantic_metric,
+        )
+        sem_tgt_loss, sem_valid_ratio = target_semantic_consistency_loss(
+            zv_target,
+            target_clf,
+            zs,
+            conf_threshold=self.semantic_conf_threshold,
+            metric=self.semantic_metric,
+        )
+
+        sem_loss = self.semantic_src_weight * sem_src_loss + self.semantic_tgt_weight * sem_tgt_loss
+        metrics['sem_loss'] = sem_loss
+        metrics['sem_src_loss'] = sem_src_loss
+        metrics['sem_tgt_loss'] = sem_tgt_loss
+        metrics['sem_valid_ratio'] = sem_valid_ratio
+        return metrics
 
     def forward(self, source, target, source_label):
         source_outputs, \
         source_x_IN_1, source_x_1, source_x_style_1a, \
         source_x_IN_2, source_x_2, source_x_style_2a, \
         source_x_IN_3, source_x_3, source_x_style_3a = self.base_network(source)
-        
+
         target_outputs, \
         target_x_IN_1, target_x_1, target_x_style_1a, \
         target_x_IN_2, target_x_2, target_x_style_2a, \
@@ -50,7 +140,7 @@ class NewTransferNet(nn.Module):
 
         # dis_loss
         dis_criterion = torch.nn.SmoothL1Loss()
-        
+
         dis_content = dis_criterion(source_x_IN_1, source_x_1) \
                 + dis_criterion(source_x_IN_2, source_x_2) \
                 + dis_criterion(source_x_IN_3, source_x_3) \
@@ -63,61 +153,48 @@ class NewTransferNet(nn.Module):
                     + dis_criterion(target_x_style_1a, target_x_1) \
                     + dis_criterion(target_x_style_2a, target_x_2) \
                     + dis_criterion(target_x_style_3a, target_x_3)
-        """
-        dis_content = dis_criterion(target_x_IN_1, target_x_1) \
-                + dis_criterion(target_x_IN_2, target_x_2) \
-                + dis_criterion(target_x_IN_3, target_x_3)
-        dis_style = dis_criterion(target_x_style_1a, target_x_1) \
-                    + dis_criterion(target_x_style_2a, target_x_2) \
-                    + dis_criterion(target_x_style_3a, target_x_3)
-        """
         dis_loss = dis_content - dis_style
-        # dis_loss = dis_content
-        # dis_loss = - dis_style
-
-        """      
-        # class-level alignment loss
-        target_clf = self.classifier_layer(target)
-        source_clf = self.classifier_layer(source)
-        source_probs = torch.softmax(source_clf, dim=1)
-        class_loss = torch.sum(source_probs * torch.nn.functional.cross_entropy(target_clf, source_label))
-        class_loss = class_loss / source_probs.size(0) 
-        """
 
         # transfer loss
         kwargs = {}
-        if self.transfer_loss == "lmmd":
+        if self.transfer_loss == 'lmmd':
             kwargs['source_label'] = source_label
             target_clf = self.classifier_layer(target)
             kwargs['target_logits'] = torch.nn.functional.softmax(target_clf, dim=1)
-        elif self.transfer_loss == "daan":
+        elif self.transfer_loss == 'daan':
             source_clf = self.classifier_layer(source)
             kwargs['source_logits'] = torch.nn.functional.softmax(source_clf, dim=1)
             target_clf = self.classifier_layer(target)
             kwargs['target_logits'] = torch.nn.functional.softmax(target_clf, dim=1)
         elif self.transfer_loss == 'bnm':
-            tar_clf = self.classifier_layer(target)
-            target = nn.Softmax(dim=1)(tar_clf)
-        
-        transfer_loss = self.adapt_loss(source, target, **kwargs)
+            target_clf = self.classifier_layer(target)
+            target = nn.Softmax(dim=1)(target_clf)
+        else:
+            target_clf = self.classifier_layer(target)
 
-        return clf_loss, dis_loss, transfer_loss
-    
+        transfer_loss = self.adapt_loss(source, target, **kwargs)
+        semantic_metrics = self._semantic_forward(source, target, source_label, target_clf)
+
+        return clf_loss, dis_loss, transfer_loss, semantic_metrics
+
     def get_parameters(self, initial_lr=1.0):
         params = [
             {'params': self.base_network.parameters(), 'lr': 0.1 * initial_lr},
             {'params': self.classifier_layer.parameters(), 'lr': 1.0 * initial_lr},
         ]
         if self.use_bottleneck:
-            params.append(
-                {'params': self.bottleneck_layer.parameters(), 'lr': 1.0 * initial_lr}
-            )
+            params.append({'params': self.bottleneck_layer.parameters(), 'lr': 1.0 * initial_lr})
+
+        if self.use_semantic_branch:
+            params.append({'params': self.visual_projector.parameters(), 'lr': 1.0 * initial_lr})
+            params.append({'params': self.semantic_projector.parameters(), 'lr': 1.0 * initial_lr})
+
         # Loss-dependent
-        if self.transfer_loss == "adv":
+        if self.transfer_loss == 'adv':
             params.append(
                 {'params': self.adapt_loss.loss_func.domain_classifier.parameters(), 'lr': 1.0 * initial_lr}
             )
-        elif self.transfer_loss == "daan":
+        elif self.transfer_loss == 'daan':
             params.append(
                 {'params': self.adapt_loss.loss_func.domain_classifier.parameters(), 'lr': 1.0 * initial_lr}
             )
@@ -134,8 +211,8 @@ class NewTransferNet(nn.Module):
         x = self.bottleneck_layer(x_4)
         clf = self.classifier_layer(x)
         return clf
-    
-    def get_features(self,x):
+
+    def get_features(self, x):
         x_4, \
         x_IN_1, x_1, x_style_1a, \
         x_IN_2, x_2, x_style_2a, \
@@ -143,7 +220,7 @@ class NewTransferNet(nn.Module):
         return self.bottleneck_layer(x_4)
 
     def epoch_based_processing(self, *args, **kwargs):
-        if self.transfer_loss == "daan":
+        if self.transfer_loss == 'daan':
             self.adapt_loss.loss_func.update_dynamic_factor(*args, **kwargs)
         else:
             pass

--- a/param.yaml
+++ b/param.yaml
@@ -19,3 +19,15 @@ n_iter_per_epoch: 500
 n_epoch: 100
 num_workers: 10
 
+# Semantic branch related (Chapter 4)
+use_semantic_branch: False
+semantic_path: ''
+semantic_dim: 0
+shared_dim: 128
+semantic_hidden_dim: 0
+semantic_conf_threshold: 0.9
+semantic_metric: cosine
+semantic_normalize: True
+semantic_loss_weight: 1.0
+semantic_src_weight: 1.0
+semantic_tgt_weight: 1.0

--- a/semantic_loader.py
+++ b/semantic_loader.py
@@ -1,0 +1,66 @@
+import json
+import os
+from typing import Optional
+
+import numpy as np
+import torch
+
+
+def _l2_normalize(x: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
+    return x / (x.norm(dim=1, keepdim=True) + eps)
+
+
+def load_semantic_embeddings(
+    semantic_path: Optional[str],
+    num_class: int,
+    normalize: bool = True,
+) -> torch.Tensor:
+    """Load class-level semantic embeddings.
+
+    Supported file formats:
+    - .npy: ndarray with shape [num_class, d_sem]
+    - .pt/.pth: tensor or dict containing key 'embeddings'
+    - .json: list[list[float]] or {'embeddings': list[list[float]]}
+
+    If semantic_path is empty or missing, fallback to one-hot semantic priors.
+    """
+    if not semantic_path or not os.path.exists(semantic_path):
+        embeddings = torch.eye(num_class, dtype=torch.float32)
+        return _l2_normalize(embeddings) if normalize else embeddings
+
+    ext = os.path.splitext(semantic_path)[1].lower()
+    if ext == ".npy":
+        arr = np.load(semantic_path)
+        embeddings = torch.tensor(arr, dtype=torch.float32)
+    elif ext in {".pt", ".pth"}:
+        obj = torch.load(semantic_path, map_location="cpu")
+        if isinstance(obj, dict):
+            if "embeddings" in obj:
+                embeddings = obj["embeddings"].float()
+            else:
+                raise ValueError("Semantic .pt/.pth dict must contain key 'embeddings'.")
+        elif isinstance(obj, torch.Tensor):
+            embeddings = obj.float()
+        else:
+            raise ValueError("Unsupported semantic tensor object in .pt/.pth.")
+    elif ext == ".json":
+        with open(semantic_path, "r", encoding="utf-8") as f:
+            obj = json.load(f)
+        if isinstance(obj, dict):
+            obj = obj.get("embeddings", None)
+        if obj is None:
+            raise ValueError("Semantic .json must be list or contain key 'embeddings'.")
+        embeddings = torch.tensor(obj, dtype=torch.float32)
+    else:
+        raise ValueError(f"Unsupported semantic embedding file extension: {ext}")
+
+    if embeddings.ndim != 2:
+        raise ValueError(f"Semantic embeddings must be 2D, got shape {tuple(embeddings.shape)}")
+    if embeddings.shape[0] != num_class:
+        raise ValueError(
+            f"Semantic embeddings class count mismatch: expected {num_class}, got {embeddings.shape[0]}"
+        )
+
+    if normalize:
+        embeddings = _l2_normalize(embeddings)
+    return embeddings

--- a/semantic_losses.py
+++ b/semantic_losses.py
@@ -1,0 +1,53 @@
+import torch
+import torch.nn.functional as F
+
+from semantic_modules import l2_normalize
+
+
+def source_semantic_alignment_loss(
+    zv_source: torch.Tensor,
+    source_label: torch.Tensor,
+    zs_prototypes: torch.Tensor,
+    metric: str = "cosine",
+) -> torch.Tensor:
+    if metric == "cosine":
+        zv = l2_normalize(zv_source)
+        zs = l2_normalize(zs_prototypes)
+        logits = torch.matmul(zv, zs.t())
+        return F.cross_entropy(logits, source_label)
+    if metric == "mse":
+        target_zs = zs_prototypes[source_label]
+        return F.mse_loss(zv_source, target_zs)
+    raise ValueError(f"Unsupported semantic metric: {metric}")
+
+
+def target_semantic_consistency_loss(
+    zv_target: torch.Tensor,
+    target_logits: torch.Tensor,
+    zs_prototypes: torch.Tensor,
+    conf_threshold: float = 0.9,
+    metric: str = "cosine",
+):
+    probs = F.softmax(target_logits, dim=1)
+    conf, pseudo = torch.max(probs, dim=1)
+    mask = conf >= conf_threshold
+
+    valid_ratio = mask.float().mean()
+    if mask.sum() == 0:
+        zero = torch.tensor(0.0, device=zv_target.device)
+        return zero, valid_ratio
+
+    zv_sel = zv_target[mask]
+    pseudo_sel = pseudo[mask]
+    if metric == "cosine":
+        zv = l2_normalize(zv_sel)
+        zs = l2_normalize(zs_prototypes)
+        logits = torch.matmul(zv, zs.t())
+        loss = F.cross_entropy(logits, pseudo_sel)
+    elif metric == "mse":
+        target_zs = zs_prototypes[pseudo_sel]
+        loss = F.mse_loss(zv_sel, target_zs)
+    else:
+        raise ValueError(f"Unsupported semantic metric: {metric}")
+
+    return loss, valid_ratio

--- a/semantic_modules.py
+++ b/semantic_modules.py
@@ -1,0 +1,22 @@
+import torch
+import torch.nn as nn
+
+
+class ProjectionHead(nn.Module):
+    def __init__(self, in_dim: int, out_dim: int, hidden_dim: int = 0):
+        super().__init__()
+        if hidden_dim and hidden_dim > 0:
+            self.net = nn.Sequential(
+                nn.Linear(in_dim, hidden_dim),
+                nn.ReLU(inplace=True),
+                nn.Linear(hidden_dim, out_dim),
+            )
+        else:
+            self.net = nn.Linear(in_dim, out_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+def l2_normalize(x: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
+    return x / (x.norm(dim=1, keepdim=True) + eps)

--- a/train.sh
+++ b/train.sh
@@ -9,12 +9,20 @@ lr=0.01 # change this to the learning rate you want to use
 # Loss weight related
 transfer_loss_weight=1 # change this to the transfer loss weight you want to use
 dis_loss_weight=1 # change this to the discriminator loss weight you want to use
+semantic_loss_weight=1 # semantic branch total weight
+
+# Semantic branch related (Chapter 4)
+use_semantic_branch=False
+semantic_path=./semantic_priors/${dataset}_semantic.npy
+semantic_conf_threshold=0.9
+semantic_src_weight=1.0
+semantic_tgt_weight=1.0
 
 # Others
 seed=1234 # change this to the seed you want to use
 patch_size=5 # change this to the patch size you want to use
 
 # Output related
-output=./log/${dataset}_${seed}_${lr}_${transfer_loss_weight}_${dis_loss_weight}_${patch_size}
+output=./log/${dataset}_${seed}_${lr}_${transfer_loss_weight}_${dis_loss_weight}_${semantic_loss_weight}_${patch_size}
 
-python main.py --config param.yaml --data_dir $data_dir --num_bands $num_bands --seed $seed --lr $lr --dis_loss_weight $dis_loss_weight --transfer_loss_weight $transfer_loss_weight --patch_size ${patch_size}| tee ${output}.log
+python main.py --config param.yaml --data_dir $data_dir --num_bands $num_bands --seed $seed --lr $lr --dis_loss_weight $dis_loss_weight --transfer_loss_weight $transfer_loss_weight --patch_size ${patch_size} --use_semantic_branch $use_semantic_branch --semantic_path $semantic_path --semantic_conf_threshold $semantic_conf_threshold --semantic_loss_weight $semantic_loss_weight --semantic_src_weight $semantic_src_weight --semantic_tgt_weight $semantic_tgt_weight | tee ${output}.log


### PR DESCRIPTION
### Motivation
- Introduce an optional semantic branch to use class-level semantic embeddings as priors for source alignment and target consistency to improve cross-domain classification.
- Provide configurable semantic priors, projection heads and loss weighting so the semantic module can be toggled and tuned from config or CLI.
- Keep backward compatibility when the semantic branch is disabled while enabling richer alignment when semantic data is available.

### Description
- Add new CLI/config options in `main.py` and `param.yaml` and wire them into `get_model` so the semantic branch can be enabled and configured via flags such as `--use_semantic_branch`, `--semantic_path`, `--semantic_conf_threshold`, and loss weights like `--semantic_loss_weight`.
- Extend `NewTransferNet` in `models.py` to support an optional semantic branch that loads semantic prototypes, creates `visual_projector` and `semantic_projector` `ProjectionHead`s, computes `source_semantic_alignment_loss` and `target_semantic_consistency_loss`, aggregates semantic metrics and returns them from `forward`, and adds projector parameters to `get_parameters` when enabled.
- Add three new modules: `semantic_loader.py` (load and validate `.npy/.pt/.pth/.json` or fallback to one-hot priors), `semantic_modules.py` (projection head and l2-normalize), and `semantic_losses.py` (source alignment and target consistency losses with `cosine`/`mse` options).
- Update training loop in `main.py` to accept semantic metrics from the model, conditionally include semantic loss in total loss, and log semantic losses and valid ratio; update `train.sh` to expose semantic CLI args and include semantic info in the output filename.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6e6280248322a90673ecf6ff893a)