### PR TITLE
Add optional semantic-prior branch (Chapter 4) with loaders, builders, losses and CLI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,43 @@ pip install -r requirements.txt
 ```
 * You can replace the training dataset/task by modifying `train.sh`.
 * Note the modification of the parameters in `train.sh`.
+
+## Chapter 4 语义先验使用说明
+
+本仓库支持第四章的可选语义分支。
+
+- 语义先验构建与文件规范（中文）：`docs/semantic_priors.md`
+- 语义先验建议存放目录：`semantic_priors/`
+
+### 第一步：构建语义先验
+```bash
+python semantic_priors/scripts/build_semantic_priors.py \
+  --config semantic_priors/examples/houston_semantic_builder.yaml
+```
+
+### 第二步：训练时加载构建结果
+```bash
+python main.py --config param.yaml --data_dir ./Dataset/Houston --num_bands 48 \
+  --use_semantic_branch True \
+  --semantic_path ./semantic_priors/Houston/semantic_bank_combined.npy
+```
+
+如果 `--semantic_path` 为空或文件不存在，代码会自动回退到 one-hot 语义先验。
+
+
+
+### 不接入 LLM，直接用论文语义描述做测试
+如果你已经有类别 coarse/fine 语义文本（如 Pavia 表格），可直接构建本地语义先验：
+
+```bash
+python semantic_priors/scripts/build_manual_semantic_bank.py   --config semantic_priors/examples/pavia_manual_semantics.yaml
+```
+
+然后训练时指定：
+
+```bash
+python main.py --config param.yaml --data_dir ./Dataset/Pavia --num_bands 102   --use_semantic_branch True   --semantic_path ./semantic_priors/Pavia/manual_semantic_bank_combined.npy
+```
+
+
+> 兼容提示：若语义先验只包含前景类（不含背景类0），而训练类别数包含背景类，加载器会自动补齐背景行。

--- a/docs/semantic_priors.md
+++ b/docs/semantic_priors.md
@@ -1,0 +1,177 @@
+# 第四章语义先验构建与文件规范（中文）
+
+本文档说明两件事：
+1. **如何构建**语义先验（LLM 生成 + 聚合 + 编码 + 置信度）
+2. **如何接入**当前训练代码（`semantic_loader.py`）
+
+---
+
+## 1. 代码中已实现的构建流程
+
+仓库提供了完整构建脚本：
+
+- `semantic_priors/scripts/build_semantic_priors.py`
+
+该脚本实现了如下流程：
+
+1. 层次化语义生成：
+   - 粗粒度（跨场景稳定语义）\(T_i^{(c)}\)
+   - 细粒度（场景条件语义）\(T_{i,src}^{(f)}, T_{i,tgt}^{(f)}\)
+2. 每类每层级进行 `K` 次生成
+3. 基于稳定阈值 \(\rho\) 的规则化聚合
+4. 文本编码与 \(\ell_2\) 归一化
+5. 基于多次生成一致性的置信度估计
+6. 导出语义原型库（`.npy`）与元数据（`.json`）
+
+支持两种生成后端：
+
+- `template`：离线模板生成（无 API 依赖，便于复现）
+- `openai`：OpenAI 兼容接口（`/v1/chat/completions`）
+
+> 当场景元信息缺失时，建议显式填 `unknown`，避免臆造先验。
+
+---
+
+## 2. 输入配置（YAML）说明
+
+示例文件：`semantic_priors/examples/houston_semantic_builder.yaml`
+
+核心字段：
+
+- `dataset`：数据集名
+- `classes`：类别列表，每个类别建议包含：
+  - `id`（必须，建议从 0 连续）
+  - `name`（必须）
+  - `alias`（可选）
+  - `definition`（可选但推荐）
+- `scene_info`：源域/目标域场景信息，建议包含：
+  - `sensor`, `season`, `region`, `resolution`, `illumination`
+
+其余关键超参：
+
+- `generation.k`：每类每层级生成次数
+- `generation.rho`：稳定语义单元保留阈值
+- `encoding.dim`：导出语义向量维度
+- `confidence.eps`：置信度下界
+- `output.merge_mode`：原型融合方式
+
+---
+
+## 3. 构建命令
+
+### 3.1 模板后端（推荐先跑通）
+
+```bash
+python semantic_priors/scripts/build_semantic_priors.py \
+  --config semantic_priors/examples/houston_semantic_builder.yaml
+```
+
+### 3.2 OpenAI 兼容后端
+
+1. 将配置中的 `generation.backend` 设为 `openai`
+2. 设置 API Key（默认读 `OPENAI_API_KEY`）
+3. 执行同一命令
+
+```bash
+export OPENAI_API_KEY="<your_key>"
+python semantic_priors/scripts/build_semantic_priors.py \
+  --config semantic_priors/examples/houston_semantic_builder.yaml
+```
+
+---
+
+## 4. 输出文件说明
+
+若 `output_dir: semantic_priors/Houston`，会生成：
+
+- `semantic_bank_coarse.npy`：粗粒度原型库 \(\mathbf{P}_c\)，形状 `[C, d_s]`
+- `semantic_bank_fine_src.npy`：源域细粒度原型库 \(\mathbf{P}_f^{(src)}\)，形状 `[C, d_s]`
+- `semantic_bank_fine_tgt.npy`：目标域细粒度原型库 \(\mathbf{P}_f^{(tgt)}\)，形状 `[C, d_s]`
+- `semantic_bank_combined.npy`：融合原型库（当前训练代码推荐直接使用）
+- `semantic_weights_coarse.npy`：粗粒度置信权重 `[C]`
+- `semantic_weights_fine_src.npy`：源域细粒度置信权重 `[C]`
+- `semantic_weights_fine_tgt.npy`：目标域细粒度置信权重 `[C]`
+- `semantic_metadata.json`：文本、权重、配置快照等元信息
+
+---
+
+## 5. 与训练代码对接
+
+当前训练加载器 `semantic_loader.py` 支持：
+
+- `.npy`：`[num_class, d_sem]`
+- `.pt/.pth`：tensor 或 `{"embeddings": tensor}`
+- `.json`：list 或 `{"embeddings": list}`
+
+第四章训练建议直接使用：
+
+- `semantic_bank_combined.npy`
+
+示例命令：
+
+```bash
+python main.py --config param.yaml --data_dir ./Dataset/Houston --num_bands 48 \
+  --use_semantic_branch True \
+  --semantic_path ./semantic_priors/Houston/semantic_bank_combined.npy
+```
+
+---
+
+## 6. 类别顺序对齐（非常重要）
+
+语义矩阵的**第 i 行必须对应训练标签中的 class id=i**。
+
+- 行索引与标签 id 不一致会导致语义错配
+- `num_class` 必须与训练时类别数一致
+
+建议：先确认 dataloader 的类别编码，再准备 `classes.id` 与原型行顺序。
+
+
+兼容说明（已在代码中实现）：
+- 若训练侧 `num_class` 包含背景类（例如 8），而语义先验只提供前景类别（例如 7 行），
+  加载器会自动在首行补一条全零背景向量，避免直接报错。
+- 建议仍尽量显式对齐类别顺序，自动补齐仅用于兼容常见 HSI 背景类场景。
+
+---
+
+## 7. 消融建议
+
+- 第三章基线：`use_semantic_branch=False`
+- 仅源域语义对齐：`use_semantic_branch=True, semantic_tgt_weight=0`
+- 仅目标域一致性：`use_semantic_branch=True, semantic_src_weight=0`
+- 第四章完整：`semantic_src_weight>0` 且 `semantic_tgt_weight>0`
+
+语义先验层级也可做消融：
+
+- 仅粗粒度：`semantic_bank_coarse.npy`
+- 仅源域细粒度：`semantic_bank_fine_src.npy`
+- 仅目标域细粒度：`semantic_bank_fine_tgt.npy`
+- 融合：`semantic_bank_combined.npy`
+
+
+## 8. 不接入 LLM 的“手工语义文本”测试（推荐快速验证）
+
+如果你已经有论文表格中的类别语义文本（coarse/fine），可直接使用以下脚本构建语义先验，不需要任何 LLM API：
+
+- 脚本：`semantic_priors/scripts/build_manual_semantic_bank.py`
+- 示例配置：`semantic_priors/examples/pavia_manual_semantics.yaml`
+
+构建命令：
+
+```bash
+python semantic_priors/scripts/build_manual_semantic_bank.py   --config semantic_priors/examples/pavia_manual_semantics.yaml
+```
+
+会输出：
+
+- `semantic_priors/Pavia/manual_semantic_bank_coarse.npy`
+- `semantic_priors/Pavia/manual_semantic_bank_fine.npy`
+- `semantic_priors/Pavia/manual_semantic_bank_combined.npy`（推荐训练时使用）
+
+训练命令示例：
+
+```bash
+python main.py --config param.yaml --data_dir ./Dataset/Pavia --num_bands 102   --use_semantic_branch True   --semantic_path ./semantic_priors/Pavia/manual_semantic_bank_combined.npy
+```
+
+> 注意：请确保 `classes.id` 与训练标签类索引完全一致（第 i 行对应 class id=i）。

--- a/main.py
+++ b/main.py
@@ -58,6 +58,19 @@ def get_parser():
     parser.add_argument('--transfer_loss_weight', type=float, default=1)
     parser.add_argument('--transfer_loss', type=str, default='mmd')
     parser.add_argument('--dis_loss_weight', type=float, default=1)
+
+    # semantic branch related
+    parser.add_argument('--use_semantic_branch', type=str2bool, default=False)
+    parser.add_argument('--semantic_path', type=str, default='')
+    parser.add_argument('--semantic_dim', type=int, default=0)
+    parser.add_argument('--shared_dim', type=int, default=128)
+    parser.add_argument('--semantic_hidden_dim', type=int, default=0)
+    parser.add_argument('--semantic_conf_threshold', type=float, default=0.9)
+    parser.add_argument('--semantic_metric', type=str, default='cosine')
+    parser.add_argument('--semantic_normalize', type=str2bool, default=True)
+    parser.add_argument('--semantic_loss_weight', type=float, default=1.0)
+    parser.add_argument('--semantic_src_weight', type=float, default=1.0)
+    parser.add_argument('--semantic_tgt_weight', type=float, default=1.0)
     return parser
 
 def set_random_seed(seed=0):
@@ -85,7 +98,23 @@ def load_data(args):
 
 def get_model(args):
     model = models.NewTransferNet(
-        args.n_class, transfer_loss=args.transfer_loss, base_net=args.backbone, max_iter=args.max_iter, input_channels=args.num_bands,use_bottleneck=args.use_bottleneck).to(args.device)
+        args.n_class,
+        transfer_loss=args.transfer_loss,
+        base_net=args.backbone,
+        max_iter=args.max_iter,
+        input_channels=args.num_bands,
+        use_bottleneck=args.use_bottleneck,
+        use_semantic_branch=args.use_semantic_branch,
+        semantic_path=args.semantic_path,
+        semantic_dim=args.semantic_dim,
+        shared_dim=args.shared_dim,
+        semantic_hidden_dim=args.semantic_hidden_dim,
+        semantic_conf_threshold=args.semantic_conf_threshold,
+        semantic_metric=args.semantic_metric,
+        semantic_normalize=args.semantic_normalize,
+        semantic_src_weight=args.semantic_src_weight,
+        semantic_tgt_weight=args.semantic_tgt_weight,
+    ).to(args.device)
     return model
 
 def get_optimizer(model, args):
@@ -125,13 +154,20 @@ def test(model, target_test_loader, args):
             
     acc = 100. * correct / len_target_dataset
     
-    # Calculate per-class accuracy
-    conf_mat = confusion_matrix(all_targets, all_preds)
-    per_class_acc = np.diag(conf_mat) / np.sum(conf_mat, axis=1)
-    
+    # Calculate per-class accuracy (robust to classes with zero test samples)
+    conf_mat = confusion_matrix(all_targets, all_preds, labels=np.arange(args.n_class))
+    class_totals = np.sum(conf_mat, axis=1)
+    per_class_acc = np.divide(
+        np.diag(conf_mat),
+        class_totals,
+        out=np.zeros_like(class_totals, dtype=float),
+        where=class_totals != 0,
+    )
+
     # Calculate OA, AA, and Kappa
     oa = accuracy_score(all_targets, all_preds)
-    aa = np.mean(per_class_acc)
+    valid_mask = class_totals != 0
+    aa = np.mean(per_class_acc[valid_mask]) if np.any(valid_mask) else 0.0
     kappa = cohen_kappa_score(all_targets, all_preds)
     
     return acc, test_loss.avg, per_class_acc, oa, aa, kappa, all_features, all_targets
@@ -169,7 +205,10 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
         train_loss_transfer = utils.AverageMeter()
         train_loss_dis = utils.AverageMeter()
         train_loss_total = utils.AverageMeter()
-        # train_loss_class = utils.AverageMeter()
+        train_loss_sem = utils.AverageMeter()
+        train_loss_sem_src = utils.AverageMeter()
+        train_loss_sem_tgt = utils.AverageMeter()
+        train_sem_valid_ratio = utils.AverageMeter()
         model.epoch_based_processing(n_batch)
 
         if max(len_target_loader, len_source_loader) != 0:
@@ -183,8 +222,11 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
                 args.device), label_source.to(args.device)
             data_target = data_target.to(args.device)
 
-            clf_loss, dis_loss, transfer_loss = model(data_source, data_target, label_source)
+            clf_loss, dis_loss, transfer_loss, semantic_metrics = model(data_source, data_target, label_source)
+            sem_loss = semantic_metrics['sem_loss']
             loss = clf_loss + args.transfer_loss_weight * transfer_loss + args.dis_loss_weight * dis_loss
+            if args.use_semantic_branch:
+                loss = loss + args.semantic_loss_weight * sem_loss
 
             optimizer.zero_grad()
             loss.backward()
@@ -196,12 +238,25 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
             train_loss_transfer.update(transfer_loss.item())
             train_loss_dis.update(dis_loss.item())
             # train_loss_class.update(class_loss.item())
+            train_loss_sem.update(sem_loss.item())
+            train_loss_sem_src.update(semantic_metrics['sem_src_loss'].item())
+            train_loss_sem_tgt.update(semantic_metrics['sem_tgt_loss'].item())
+            train_sem_valid_ratio.update(semantic_metrics['sem_valid_ratio'].item())
             train_loss_total.update(loss.item())
 
-        log.append([train_loss_clf.avg, train_loss_transfer.avg, train_loss_total.avg])
+        log.append([
+            train_loss_clf.avg,
+            train_loss_transfer.avg,
+            train_loss_dis.avg,
+            train_loss_sem.avg,
+            train_loss_sem_src.avg,
+            train_loss_sem_tgt.avg,
+            train_sem_valid_ratio.avg,
+            train_loss_total.avg,
+        ])
 
-        info = 'Epoch: [{:2d}/{}], cls_loss: {:.4f}, transfer_loss: {:.4f}, dis_loss: {:.4f}, total_Loss: {:.4f}'.format(
-            e, args.n_epoch, train_loss_clf.avg, train_loss_transfer.avg, train_loss_dis.avg,train_loss_total.avg)
+        info = 'Epoch: [{:2d}/{}], cls_loss: {:.4f}, transfer_loss: {:.4f}, dis_loss: {:.4f}, sem_loss: {:.4f}, sem_src: {:.4f}, sem_tgt: {:.4f}, sem_ratio: {:.4f}, total_Loss: {:.4f}'.format(
+            e, args.n_epoch, train_loss_clf.avg, train_loss_transfer.avg, train_loss_dis.avg, train_loss_sem.avg, train_loss_sem_src.avg, train_loss_sem_tgt.avg, train_sem_valid_ratio.avg, train_loss_total.avg)
         # Test
         stop += 1
         test_acc, test_loss, per_class_acc, oa, aa, kappa, all_features, all_targets = test(model, target_test_loader, args)

--- a/models.py
+++ b/models.py
@@ -1,15 +1,41 @@
 import torch
 import torch.nn as nn
-from transfer_losses import TransferLoss
+
 import backbones
+from semantic_loader import load_semantic_embeddings
+from semantic_modules import ProjectionHead
+from semantic_losses import source_semantic_alignment_loss, target_semantic_consistency_loss
+from transfer_losses import TransferLoss
+
 
 class NewTransferNet(nn.Module):
-    def __init__(self, num_class, base_net='rsp_resnet50', transfer_loss='mmd', use_bottleneck=True, bottleneck_width=256, max_iter=1000, input_channels=3,**kwargs):
+    def __init__(
+        self,
+        num_class,
+        base_net='rsp_resnet50',
+        transfer_loss='mmd',
+        use_bottleneck=True,
+        bottleneck_width=256,
+        max_iter=1000,
+        input_channels=3,
+        use_semantic_branch=False,
+        semantic_path='',
+        semantic_dim=0,
+        shared_dim=128,
+        semantic_hidden_dim=0,
+        semantic_conf_threshold=0.9,
+        semantic_metric='cosine',
+        semantic_normalize=True,
+        semantic_src_weight=1.0,
+        semantic_tgt_weight=1.0,
+        **kwargs,
+    ):
         super(NewTransferNet, self).__init__()
         self.num_class = num_class
         self.base_network = backbones.get_backbone(base_net, input_channels=input_channels)
         self.use_bottleneck = use_bottleneck
         self.transfer_loss = transfer_loss
+
         if self.use_bottleneck:
             bottleneck_list = [
                 nn.Linear(self.base_network.output_num(), bottleneck_width),
@@ -21,36 +47,103 @@ class NewTransferNet(nn.Module):
             feature_dim = self.base_network.output_num()
 
         self.classifier_layer = nn.Linear(feature_dim, num_class)
+
         transfer_loss_args = {
-            "loss_type": self.transfer_loss,
-            "max_iter": max_iter,
-            "num_class": num_class
+            'loss_type': self.transfer_loss,
+            'max_iter': max_iter,
+            'num_class': num_class,
         }
         self.adapt_loss = TransferLoss(**transfer_loss_args)
         self.criterion = torch.nn.CrossEntropyLoss()
+
+        # Semantic branch
+        self.use_semantic_branch = use_semantic_branch
+        self.semantic_conf_threshold = semantic_conf_threshold
+        self.semantic_metric = semantic_metric
+        self.semantic_src_weight = semantic_src_weight
+        self.semantic_tgt_weight = semantic_tgt_weight
+
+        self.visual_projector = None
+        self.semantic_projector = None
+
+        if self.use_semantic_branch:
+            semantic_bank = load_semantic_embeddings(
+                semantic_path=semantic_path,
+                num_class=num_class,
+                normalize=semantic_normalize,
+            )
+            # allow optional explicit semantic_dim but keep compatibility if mismatch
+            if semantic_dim and semantic_dim > 0 and semantic_bank.shape[1] != semantic_dim:
+                raise ValueError(
+                    f'semantic_dim mismatch: expected {semantic_dim}, got {semantic_bank.shape[1]} from semantic bank'
+                )
+            semantic_dim = semantic_bank.shape[1]
+            self.register_buffer('semantic_bank', semantic_bank)
+
+            self.visual_projector = ProjectionHead(feature_dim, shared_dim, hidden_dim=semantic_hidden_dim)
+            self.semantic_projector = ProjectionHead(semantic_dim, shared_dim, hidden_dim=semantic_hidden_dim)
+
+    def _semantic_forward(self, source_feat, target_feat, source_label, target_clf):
+        zero = torch.tensor(0.0, device=source_feat.device)
+        metrics = {
+            'sem_loss': zero,
+            'sem_src_loss': zero,
+            'sem_tgt_loss': zero,
+            'sem_valid_ratio': zero,
+        }
+        if not self.use_semantic_branch:
+            return metrics
+
+        zv_source = self.visual_projector(source_feat)
+        zv_target = self.visual_projector(target_feat)
+        zs = self.semantic_projector(self.semantic_bank)
+
+        sem_src_loss = source_semantic_alignment_loss(
+            zv_source,
+            source_label,
+            zs,
+            metric=self.semantic_metric,
+        )
+        sem_tgt_loss, sem_valid_ratio = target_semantic_consistency_loss(
+            zv_target,
+            target_clf,
+            zs,
+            conf_threshold=self.semantic_conf_threshold,
+            metric=self.semantic_metric,
+        )
+
+        sem_loss = self.semantic_src_weight * sem_src_loss + self.semantic_tgt_weight * sem_tgt_loss
+        metrics['sem_loss'] = sem_loss
+        metrics['sem_src_loss'] = sem_src_loss
+        metrics['sem_tgt_loss'] = sem_tgt_loss
+        metrics['sem_valid_ratio'] = sem_valid_ratio
+        return metrics
 
     def forward(self, source, target, source_label):
         source_outputs, \
         source_x_IN_1, source_x_1, source_x_style_1a, \
         source_x_IN_2, source_x_2, source_x_style_2a, \
         source_x_IN_3, source_x_3, source_x_style_3a = self.base_network(source)
-        
+
         target_outputs, \
         target_x_IN_1, target_x_1, target_x_style_1a, \
         target_x_IN_2, target_x_2, target_x_style_2a, \
         target_x_IN_3, target_x_3, target_x_style_3a = self.base_network(target)
 
         if self.use_bottleneck:
-            source = self.bottleneck_layer(source_outputs)
-            target = self.bottleneck_layer(target_outputs)
+            source_feat = self.bottleneck_layer(source_outputs)
+            target_feat = self.bottleneck_layer(target_outputs)
+        else:
+            source_feat = source_outputs
+            target_feat = target_outputs
 
         # classification loss
-        source_clf = self.classifier_layer(source)
+        source_clf = self.classifier_layer(source_feat)
         clf_loss = self.criterion(source_clf, source_label)
 
         # dis_loss
         dis_criterion = torch.nn.SmoothL1Loss()
-        
+
         dis_content = dis_criterion(source_x_IN_1, source_x_1) \
                 + dis_criterion(source_x_IN_2, source_x_2) \
                 + dis_criterion(source_x_IN_3, source_x_3) \
@@ -63,61 +156,49 @@ class NewTransferNet(nn.Module):
                     + dis_criterion(target_x_style_1a, target_x_1) \
                     + dis_criterion(target_x_style_2a, target_x_2) \
                     + dis_criterion(target_x_style_3a, target_x_3)
-        """
-        dis_content = dis_criterion(target_x_IN_1, target_x_1) \
-                + dis_criterion(target_x_IN_2, target_x_2) \
-                + dis_criterion(target_x_IN_3, target_x_3)
-        dis_style = dis_criterion(target_x_style_1a, target_x_1) \
-                    + dis_criterion(target_x_style_2a, target_x_2) \
-                    + dis_criterion(target_x_style_3a, target_x_3)
-        """
         dis_loss = dis_content - dis_style
-        # dis_loss = dis_content
-        # dis_loss = - dis_style
-
-        """      
-        # class-level alignment loss
-        target_clf = self.classifier_layer(target)
-        source_clf = self.classifier_layer(source)
-        source_probs = torch.softmax(source_clf, dim=1)
-        class_loss = torch.sum(source_probs * torch.nn.functional.cross_entropy(target_clf, source_label))
-        class_loss = class_loss / source_probs.size(0) 
-        """
 
         # transfer loss
         kwargs = {}
-        if self.transfer_loss == "lmmd":
+        if self.transfer_loss == 'lmmd':
             kwargs['source_label'] = source_label
-            target_clf = self.classifier_layer(target)
+            target_clf = self.classifier_layer(target_feat)
             kwargs['target_logits'] = torch.nn.functional.softmax(target_clf, dim=1)
-        elif self.transfer_loss == "daan":
-            source_clf = self.classifier_layer(source)
+        elif self.transfer_loss == 'daan':
+            source_clf = self.classifier_layer(source_feat)
             kwargs['source_logits'] = torch.nn.functional.softmax(source_clf, dim=1)
-            target_clf = self.classifier_layer(target)
+            target_clf = self.classifier_layer(target_feat)
             kwargs['target_logits'] = torch.nn.functional.softmax(target_clf, dim=1)
         elif self.transfer_loss == 'bnm':
-            tar_clf = self.classifier_layer(target)
-            target = nn.Softmax(dim=1)(tar_clf)
-        
-        transfer_loss = self.adapt_loss(source, target, **kwargs)
+            target_clf = self.classifier_layer(target_feat)
+            target_prob = nn.Softmax(dim=1)(target_clf)
+        else:
+            target_clf = self.classifier_layer(target_feat)
 
-        return clf_loss, dis_loss, transfer_loss
-    
+        transfer_target = target_prob if self.transfer_loss == 'bnm' else target_feat
+        transfer_loss = self.adapt_loss(source_feat, transfer_target, **kwargs)
+        semantic_metrics = self._semantic_forward(source_feat, target_feat, source_label, target_clf)
+
+        return clf_loss, dis_loss, transfer_loss, semantic_metrics
+
     def get_parameters(self, initial_lr=1.0):
         params = [
             {'params': self.base_network.parameters(), 'lr': 0.1 * initial_lr},
             {'params': self.classifier_layer.parameters(), 'lr': 1.0 * initial_lr},
         ]
         if self.use_bottleneck:
-            params.append(
-                {'params': self.bottleneck_layer.parameters(), 'lr': 1.0 * initial_lr}
-            )
+            params.append({'params': self.bottleneck_layer.parameters(), 'lr': 1.0 * initial_lr})
+
+        if self.use_semantic_branch:
+            params.append({'params': self.visual_projector.parameters(), 'lr': 1.0 * initial_lr})
+            params.append({'params': self.semantic_projector.parameters(), 'lr': 1.0 * initial_lr})
+
         # Loss-dependent
-        if self.transfer_loss == "adv":
+        if self.transfer_loss == 'adv':
             params.append(
                 {'params': self.adapt_loss.loss_func.domain_classifier.parameters(), 'lr': 1.0 * initial_lr}
             )
-        elif self.transfer_loss == "daan":
+        elif self.transfer_loss == 'daan':
             params.append(
                 {'params': self.adapt_loss.loss_func.domain_classifier.parameters(), 'lr': 1.0 * initial_lr}
             )
@@ -131,19 +212,19 @@ class NewTransferNet(nn.Module):
         x_IN_1, x_1, x_style_1a, \
         x_IN_2, x_2, x_style_2a, \
         x_IN_3, x_3, x_style_3a = self.base_network(x)
-        x = self.bottleneck_layer(x_4)
-        clf = self.classifier_layer(x)
+        feat = self.bottleneck_layer(x_4) if self.use_bottleneck else x_4
+        clf = self.classifier_layer(feat)
         return clf
-    
-    def get_features(self,x):
+
+    def get_features(self, x):
         x_4, \
         x_IN_1, x_1, x_style_1a, \
         x_IN_2, x_2, x_style_2a, \
         x_IN_3, x_3, x_style_3a = self.base_network(x)
-        return self.bottleneck_layer(x_4)
+        return self.bottleneck_layer(x_4) if self.use_bottleneck else x_4
 
     def epoch_based_processing(self, *args, **kwargs):
-        if self.transfer_loss == "daan":
+        if self.transfer_loss == 'daan':
             self.adapt_loss.loss_func.update_dynamic_factor(*args, **kwargs)
         else:
             pass

--- a/param.yaml
+++ b/param.yaml
@@ -19,3 +19,15 @@ n_iter_per_epoch: 500
 n_epoch: 100
 num_workers: 10
 
+# Semantic branch related (Chapter 4)
+use_semantic_branch: False
+semantic_path: ''
+semantic_dim: 0
+shared_dim: 128
+semantic_hidden_dim: 0
+semantic_conf_threshold: 0.9
+semantic_metric: cosine
+semantic_normalize: True
+semantic_loss_weight: 1.0
+semantic_src_weight: 1.0
+semantic_tgt_weight: 1.0

--- a/semantic_loader.py
+++ b/semantic_loader.py
@@ -1,0 +1,80 @@
+import json
+import os
+from typing import Optional
+
+import numpy as np
+import torch
+
+
+def _l2_normalize(x: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
+    return x / (x.norm(dim=1, keepdim=True) + eps)
+
+
+def load_semantic_embeddings(
+    semantic_path: Optional[str],
+    num_class: int,
+    normalize: bool = True,
+) -> torch.Tensor:
+    """Load class-level semantic embeddings.
+
+    Supported file formats:
+    - .npy: ndarray with shape [num_class, d_sem]
+    - .pt/.pth: tensor or dict containing key 'embeddings'
+    - .json: list[list[float]] or {'embeddings': list[list[float]]}
+
+    If semantic_path is empty or missing, fallback to one-hot semantic priors.
+    """
+    if not semantic_path or not os.path.exists(semantic_path):
+        embeddings = torch.eye(num_class, dtype=torch.float32)
+        return _l2_normalize(embeddings) if normalize else embeddings
+
+    ext = os.path.splitext(semantic_path)[1].lower()
+    if ext == ".npy":
+        arr = np.load(semantic_path)
+        embeddings = torch.tensor(arr, dtype=torch.float32)
+    elif ext in {".pt", ".pth"}:
+        obj = torch.load(semantic_path, map_location="cpu")
+        if isinstance(obj, dict):
+            if "embeddings" in obj:
+                embeddings = obj["embeddings"].float()
+            else:
+                raise ValueError("Semantic .pt/.pth dict must contain key 'embeddings'.")
+        elif isinstance(obj, torch.Tensor):
+            embeddings = obj.float()
+        else:
+            raise ValueError("Unsupported semantic tensor object in .pt/.pth.")
+    elif ext == ".json":
+        with open(semantic_path, "r", encoding="utf-8") as f:
+            obj = json.load(f)
+        if isinstance(obj, dict):
+            obj = obj.get("embeddings", None)
+        if obj is None:
+            raise ValueError("Semantic .json must be list or contain key 'embeddings'.")
+        embeddings = torch.tensor(obj, dtype=torch.float32)
+    else:
+        raise ValueError(f"Unsupported semantic embedding file extension: {ext}")
+
+    if embeddings.ndim != 2:
+        raise ValueError(f"Semantic embeddings must be 2D, got shape {tuple(embeddings.shape)}")
+
+    # Compatibility case:
+    # many HSI datasets use label 0 as background/unlabeled.
+    # Training may set num_class to include this background index,
+    # while manual semantic priors are provided only for foreground classes.
+    # If semantic rows are num_class - 1, prepend one background row automatically.
+    if embeddings.shape[0] == num_class - 1:
+        bg = torch.zeros((1, embeddings.shape[1]), dtype=embeddings.dtype)
+        embeddings = torch.cat([bg, embeddings], dim=0)
+        print(
+            f"[semantic_loader] Detected foreground-only semantic bank; prepended background row. "
+            f"Adjusted shape: {tuple(embeddings.shape)}"
+        )
+
+    if embeddings.shape[0] != num_class:
+        raise ValueError(
+            f"Semantic embeddings class count mismatch: expected {num_class}, got {embeddings.shape[0]}"
+        )
+
+    if normalize:
+        embeddings = _l2_normalize(embeddings)
+    return embeddings

--- a/semantic_losses.py
+++ b/semantic_losses.py
@@ -1,0 +1,53 @@
+import torch
+import torch.nn.functional as F
+
+from semantic_modules import l2_normalize
+
+
+def source_semantic_alignment_loss(
+    zv_source: torch.Tensor,
+    source_label: torch.Tensor,
+    zs_prototypes: torch.Tensor,
+    metric: str = "cosine",
+) -> torch.Tensor:
+    if metric == "cosine":
+        zv = l2_normalize(zv_source)
+        zs = l2_normalize(zs_prototypes)
+        logits = torch.matmul(zv, zs.t())
+        return F.cross_entropy(logits, source_label)
+    if metric == "mse":
+        target_zs = zs_prototypes[source_label]
+        return F.mse_loss(zv_source, target_zs)
+    raise ValueError(f"Unsupported semantic metric: {metric}")
+
+
+def target_semantic_consistency_loss(
+    zv_target: torch.Tensor,
+    target_logits: torch.Tensor,
+    zs_prototypes: torch.Tensor,
+    conf_threshold: float = 0.9,
+    metric: str = "cosine",
+):
+    probs = F.softmax(target_logits, dim=1)
+    conf, pseudo = torch.max(probs, dim=1)
+    mask = conf >= conf_threshold
+
+    valid_ratio = mask.float().mean()
+    if mask.sum() == 0:
+        zero = torch.tensor(0.0, device=zv_target.device)
+        return zero, valid_ratio
+
+    zv_sel = zv_target[mask]
+    pseudo_sel = pseudo[mask]
+    if metric == "cosine":
+        zv = l2_normalize(zv_sel)
+        zs = l2_normalize(zs_prototypes)
+        logits = torch.matmul(zv, zs.t())
+        loss = F.cross_entropy(logits, pseudo_sel)
+    elif metric == "mse":
+        target_zs = zs_prototypes[pseudo_sel]
+        loss = F.mse_loss(zv_sel, target_zs)
+    else:
+        raise ValueError(f"Unsupported semantic metric: {metric}")
+
+    return loss, valid_ratio

--- a/semantic_modules.py
+++ b/semantic_modules.py
@@ -1,0 +1,22 @@
+import torch
+import torch.nn as nn
+
+
+class ProjectionHead(nn.Module):
+    def __init__(self, in_dim: int, out_dim: int, hidden_dim: int = 0):
+        super().__init__()
+        if hidden_dim and hidden_dim > 0:
+            self.net = nn.Sequential(
+                nn.Linear(in_dim, hidden_dim),
+                nn.ReLU(inplace=True),
+                nn.Linear(hidden_dim, out_dim),
+            )
+        else:
+            self.net = nn.Linear(in_dim, out_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+def l2_normalize(x: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
+    return x / (x.norm(dim=1, keepdim=True) + eps)

--- a/semantic_priors/README.md
+++ b/semantic_priors/README.md
@@ -1,0 +1,22 @@
+该目录用于存放第四章语义先验相关资源。
+
+## 推荐目录结构
+- `scripts/build_semantic_priors.py`：语义先验构建脚本
+- `examples/*.yaml`：构建配置示例
+- `<Dataset>/semantic_bank_*.npy`：构建产出的语义原型库
+
+## 快速开始
+```bash
+python semantic_priors/scripts/build_semantic_priors.py \
+  --config semantic_priors/examples/houston_semantic_builder.yaml
+```
+
+完整说明请见：`docs/semantic_priors.md`。
+
+
+## 无 LLM 的手工文本构建
+可将论文中的 coarse/fine 类别语义直接写入 YAML（示例：`examples/pavia_manual_semantics.yaml`），然后运行：
+
+```bash
+python semantic_priors/scripts/build_manual_semantic_bank.py   --config semantic_priors/examples/pavia_manual_semantics.yaml
+```

--- a/semantic_priors/examples/houston_semantic_builder.yaml
+++ b/semantic_priors/examples/houston_semantic_builder.yaml
@@ -1,0 +1,69 @@
+dataset: Houston
+output_dir: semantic_priors/Houston
+
+classes:
+  - id: 0
+    name: Healthy grass
+    alias: ["grass", "lawn"]
+    definition: "Vegetation-covered surfaces with relatively dense and healthy growth"
+  - id: 1
+    name: Stressed grass
+    alias: ["dry grass", "sparse grass"]
+    definition: "Vegetation with reduced vigor, lower moisture, or stress-related appearance"
+  - id: 2
+    name: Tree
+    alias: ["woody vegetation"]
+    definition: "Tall perennial woody vegetation with canopy structure"
+  - id: 3
+    name: Water
+    alias: ["river", "pond"]
+    definition: "Open surface water body with distinct low-reflectance characteristics"
+  - id: 4
+    name: Residential
+    alias: ["housing area"]
+    definition: "Built-up residential area with buildings, roads and mixed impervious surfaces"
+  - id: 5
+    name: Commercial
+    alias: ["business district"]
+    definition: "Urban commercial area with dense impervious materials and complex structures"
+  - id: 6
+    name: Road
+    alias: ["transport corridor"]
+    definition: "Linear man-made transportation surfaces such as asphalt or concrete roads"
+
+scene_info:
+  src:
+    sensor: unknown
+    season: unknown
+    region: Houston
+    resolution: unknown
+    illumination: unknown
+  tgt:
+    sensor: unknown
+    season: unknown
+    region: Houston
+    resolution: unknown
+    illumination: unknown
+
+generation:
+  backend: template  # template | openai
+  k: 5
+  rho: 0.6
+  max_sentences: 4
+
+# only used when generation.backend=openai
+openai:
+  base_url: https://api.openai.com
+  model: gpt-4o-mini
+  api_key_env: OPENAI_API_KEY
+  temperature: 0.2
+  max_tokens: 260
+
+encoding:
+  dim: 256
+
+confidence:
+  eps: 0.05
+
+output:
+  merge_mode: weighted_mean  # weighted_mean | coarse_only | fine_src_only | fine_tgt_only

--- a/semantic_priors/examples/pavia_manual_semantics.yaml
+++ b/semantic_priors/examples/pavia_manual_semantics.yaml
@@ -1,0 +1,40 @@
+dataset: Pavia
+output_dir: semantic_priors/Pavia
+encoding_dim: 256
+merge_mode: concat
+
+classes:
+  - id: 0
+    name: Trees
+    coarse: "A hyperspectral image of trees"
+    fine: "Trees are frequently located along roads or urban green areas. In hyperspectral imagery they usually appear as clustered circular canopy structures."
+
+  - id: 1
+    name: Asphalt
+    coarse: "A hyperspectral image of asphalt roads"
+    fine: "Asphalt roads typically form elongated strip-shaped structures. Vegetation such as trees is often distributed along both sides of the road."
+
+  - id: 2
+    name: Brick
+    coarse: "A hyperspectral image of brick surfaces"
+    fine: "Brick surfaces are commonly used as paving materials. In hyperspectral imagery they often exhibit relatively regular strip-like or block patterns."
+
+  - id: 3
+    name: Bitumen
+    coarse: "A hyperspectral image of bitumen surfaces"
+    fine: "Bitumen is commonly used as a covering material for building surfaces. In hyperspectral imagery it usually forms relatively smooth and homogeneous regions."
+
+  - id: 4
+    name: Shadow
+    coarse: "A hyperspectral image of shadows"
+    fine: "Shadows typically occur near tall structures such as buildings. In hyperspectral imagery shadow regions usually appear very dark due to reduced reflected radiation."
+
+  - id: 5
+    name: Meadow
+    coarse: "A hyperspectral image of meadow"
+    fine: "Meadows are typically covered by grass vegetation. In hyperspectral imagery they often appear as relatively homogeneous green regions."
+
+  - id: 6
+    name: Bare soil
+    coarse: "A hyperspectral image of bare soil"
+    fine: "Bare soil surfaces lack vegetation cover. In hyperspectral imagery they often appear gray or grayish-black with relatively rough textures."

--- a/semantic_priors/scripts/build_manual_semantic_bank.py
+++ b/semantic_priors/scripts/build_manual_semantic_bank.py
@@ -1,0 +1,99 @@
+import argparse
+import json
+import os
+from typing import List
+
+import numpy as np
+import yaml
+from sklearn.decomposition import TruncatedSVD
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+
+def l2_normalize(x: np.ndarray, eps: float = 1e-12) -> np.ndarray:
+    norm = np.linalg.norm(x, axis=1, keepdims=True)
+    return x / np.clip(norm, eps, None)
+
+
+def encode_texts(texts: List[str], dim: int = 256) -> np.ndarray:
+    tfidf = TfidfVectorizer(max_features=max(1024, dim * 8), ngram_range=(1, 2))
+    x = tfidf.fit_transform(texts)
+
+    if x.shape[1] > dim:
+        svd_dim = min(dim, x.shape[0] - 1, x.shape[1] - 1)
+        if svd_dim >= 2:
+            svd = TruncatedSVD(n_components=svd_dim, random_state=0)
+            z = svd.fit_transform(x)
+        else:
+            z = x.toarray()
+    else:
+        z = x.toarray()
+
+    z = z.astype(np.float32)
+    if z.shape[1] < dim:
+        pad = np.zeros((z.shape[0], dim - z.shape[1]), dtype=np.float32)
+        z = np.concatenate([z, pad], axis=1)
+    else:
+        z = z[:, :dim]
+
+    return l2_normalize(z)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Build semantic bank from manual text descriptions (no LLM).')
+    parser.add_argument('--config', type=str, required=True, help='YAML config path')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    with open(args.config, 'r', encoding='utf-8') as f:
+        cfg = yaml.safe_load(f)
+
+    dataset = cfg['dataset']
+    out_dir = cfg.get('output_dir', f'semantic_priors/{dataset}')
+    dim = int(cfg.get('encoding_dim', 256))
+    merge_mode = cfg.get('merge_mode', 'concat')  # concat | coarse_only | fine_only
+
+    classes = sorted(cfg['classes'], key=lambda x: int(x['id']))
+    coarse = [c['coarse'] for c in classes]
+    fine = [c['fine'] for c in classes]
+
+    emb_coarse = encode_texts(coarse, dim=dim)
+    emb_fine = encode_texts(fine, dim=dim)
+
+    if merge_mode == 'coarse_only':
+        emb_combined = emb_coarse
+    elif merge_mode == 'fine_only':
+        emb_combined = emb_fine
+    elif merge_mode == 'concat':
+        emb_combined = np.concatenate([emb_coarse, emb_fine], axis=1)
+        emb_combined = l2_normalize(emb_combined)
+    else:
+        raise ValueError(f'Unsupported merge_mode: {merge_mode}')
+
+    os.makedirs(out_dir, exist_ok=True)
+    np.save(os.path.join(out_dir, 'manual_semantic_bank_coarse.npy'), emb_coarse)
+    np.save(os.path.join(out_dir, 'manual_semantic_bank_fine.npy'), emb_fine)
+    np.save(os.path.join(out_dir, 'manual_semantic_bank_combined.npy'), emb_combined)
+
+    meta = {
+        'dataset': dataset,
+        'encoding_dim': dim,
+        'merge_mode': merge_mode,
+        'num_classes': len(classes),
+        'classes': classes,
+        'output_files': [
+            'manual_semantic_bank_coarse.npy',
+            'manual_semantic_bank_fine.npy',
+            'manual_semantic_bank_combined.npy',
+        ],
+    }
+    with open(os.path.join(out_dir, 'manual_semantic_bank_meta.json'), 'w', encoding='utf-8') as f:
+        json.dump(meta, f, ensure_ascii=False, indent=2)
+
+    print(f'[Done] Manual semantic banks saved to: {out_dir}')
+    print('- manual_semantic_bank_combined.npy (recommended for training)')
+
+
+if __name__ == '__main__':
+    main()

--- a/semantic_priors/scripts/build_semantic_priors.py
+++ b/semantic_priors/scripts/build_semantic_priors.py
@@ -1,0 +1,342 @@
+import argparse
+import json
+import os
+import re
+import urllib.request
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import yaml
+from sklearn.decomposition import TruncatedSVD
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+
+SLOTS = ["type", "composition", "morphology", "texture", "context", "condition"]
+
+
+@dataclass
+class ClassSpec:
+    class_id: int
+    name: str
+    alias: List[str]
+    definition: str
+
+
+class SemanticPriorBuilder:
+    """Hierarchical semantic-prior constructor for Chapter 4.
+
+    Pipeline:
+    1) hierarchical text generation (coarse + fine src/tgt)
+    2) K-sampling and rule-based aggregation
+    3) text embedding + l2 normalization
+    4) consistency-based confidence estimation
+    5) export prototype banks and merged bank
+    """
+
+    def __init__(self, cfg: Dict):
+        self.cfg = cfg
+        self.dataset = cfg["dataset"]
+        self.classes = self._parse_classes(cfg["classes"])
+        self.scene_info = cfg["scene_info"]
+        self.k = int(cfg.get("generation", {}).get("k", 5))
+        self.rho = float(cfg.get("generation", {}).get("rho", 0.6))
+        self.max_sentences = int(cfg.get("generation", {}).get("max_sentences", 4))
+        self.min_weight = float(cfg.get("confidence", {}).get("eps", 0.05))
+        self.encoding_dim = int(cfg.get("encoding", {}).get("dim", 256))
+        self.output_dir = cfg.get("output_dir", f"semantic_priors/{self.dataset}")
+        self.merge_mode = cfg.get("output", {}).get("merge_mode", "weighted_mean")
+        self.generation_backend = cfg.get("generation", {}).get("backend", "template")
+        self.openai_cfg = cfg.get("openai", {})
+
+    @staticmethod
+    def _parse_classes(raw: List[Dict]) -> List[ClassSpec]:
+        classes = []
+        for item in raw:
+            classes.append(
+                ClassSpec(
+                    class_id=int(item["id"]),
+                    name=item["name"],
+                    alias=item.get("alias", []),
+                    definition=item.get("definition", "unknown"),
+                )
+            )
+        classes = sorted(classes, key=lambda x: x.class_id)
+        return classes
+
+
+    def _call_openai_compatible(self, prompt: str) -> str:
+        api_key_env = self.openai_cfg.get("api_key_env", "OPENAI_API_KEY")
+        api_key = os.getenv(api_key_env, "")
+        if not api_key:
+            raise RuntimeError(f"Missing API key env: {api_key_env}")
+
+        base_url = self.openai_cfg.get("base_url", "https://api.openai.com")
+        model = self.openai_cfg.get("model", "gpt-4o-mini")
+        temperature = float(self.openai_cfg.get("temperature", 0.2))
+        max_tokens = int(self.openai_cfg.get("max_tokens", 260))
+
+        url = base_url.rstrip("/") + "/v1/chat/completions"
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": "You are a remote-sensing semantic assistant."},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            obj = json.loads(resp.read().decode("utf-8"))
+        return obj["choices"][0]["message"]["content"].strip()
+
+    def _build_coarse_prompt(self, cls: ClassSpec, seed: int) -> str:
+        alias = ", ".join(cls.alias) if cls.alias else "none"
+        return (
+            f"Class name: {cls.name}\n"
+            f"Alias: {alias}\n"
+            f"Definition: {cls.definition}\n"
+            "Task: generate concise coarse-grained, scene-invariant remote-sensing semantics. "
+            "Must include slots exactly: Type, Composition, Morphology, Texture, Context, Condition. "
+            "Use objective statements only and keep <= 6 sentences. "
+            f"Variant marker: {seed}."
+        )
+
+    def _build_fine_prompt(self, cls: ClassSpec, domain: str, seed: int) -> str:
+        alias = ", ".join(cls.alias) if cls.alias else "none"
+        scene_txt = self._scene_to_text(domain)
+        return (
+            f"Class name: {cls.name}\n"
+            f"Alias: {alias}\n"
+            f"Definition: {cls.definition}\n"
+            f"Scene info ({domain}): {scene_txt}\n"
+            "Task: generate concise fine-grained, scene-aware remote-sensing semantics. "
+            "Must include slots exactly: Type, Composition, Morphology, Texture, Context, Condition. "
+            "Do not fabricate unknown fields and keep <= 6 sentences. "
+            f"Variant marker: {seed}."
+        )
+
+    def _scene_to_text(self, domain: str) -> str:
+        info = self.scene_info.get(domain, {})
+        ordered_keys = ["sensor", "season", "region", "resolution", "illumination"]
+        parts = [f"{k}={info.get(k, 'unknown')}" for k in ordered_keys]
+        return "; ".join(parts)
+
+    def _generate_coarse_once(self, cls: ClassSpec, seed: int) -> str:
+        if self.generation_backend == "openai":
+            prompt = self._build_coarse_prompt(cls, seed)
+            return self._call_openai_compatible(prompt)
+        alias = ", ".join(cls.alias) if cls.alias else "none"
+        return (
+            f"Type: {cls.name} is a land-cover category in hyperspectral remote sensing. "
+            f"Composition: {cls.definition}. Known aliases: {alias}. "
+            f"Morphology: typically shows stable spatial organization and class-specific structural layout. "
+            f"Texture: presents relatively consistent spectral-spatial texture under cross-scene observation. "
+            f"Context: appears with meaningful neighborhood relations to surrounding classes. "
+            f"Condition: coarse description focuses on scene-invariant semantic properties. "
+            f"Variant marker: v{seed}."
+        )
+
+    def _generate_fine_once(self, cls: ClassSpec, domain: str, seed: int) -> str:
+        if self.generation_backend == "openai":
+            prompt = self._build_fine_prompt(cls, domain, seed)
+            return self._call_openai_compatible(prompt)
+        scene_txt = self._scene_to_text(domain)
+        return (
+            f"Type: {cls.name} under {domain} domain condition. "
+            f"Composition: follows class definition ({cls.definition}) with domain-aware observation details. "
+            f"Morphology: boundary visibility and shape continuity may vary with scene setting ({scene_txt}). "
+            f"Texture: texture density, local contrast, and spectral response can change across conditions. "
+            f"Context: neighboring category interactions can shift under domain context ({domain}). "
+            f"Condition: scene-aware factors include {scene_txt}; unknown fields remain unknown. "
+            f"Variant marker: v{seed}."
+        )
+
+    @staticmethod
+    def _normalize_text(text: str) -> str:
+        text = text.lower().strip()
+        text = re.sub(r"\s+", " ", text)
+        return text
+
+    def _extract_units(self, text: str) -> Dict[str, str]:
+        units = {}
+        for slot in SLOTS:
+            m = re.search(rf"{slot}:\s*(.*?)(?:\.\s|$)", text, flags=re.IGNORECASE)
+            if m:
+                units[slot] = self._normalize_text(m.group(1))
+        return units
+
+    def _aggregate_candidates(self, texts: List[str]) -> str:
+        unit_counts: Dict[Tuple[str, str], int] = {}
+        for t in texts:
+            units = self._extract_units(t)
+            for slot, val in units.items():
+                key = (slot, val)
+                unit_counts[key] = unit_counts.get(key, 0) + 1
+
+        kept = {slot: [] for slot in SLOTS}
+        threshold = max(1, int(np.ceil(self.rho * len(texts))))
+        for (slot, val), cnt in unit_counts.items():
+            if cnt >= threshold:
+                kept[slot].append((val, cnt))
+
+        composed = []
+        for slot in SLOTS:
+            if kept[slot]:
+                kept[slot].sort(key=lambda x: (-x[1], x[0]))
+                composed.append(f"{slot}: {kept[slot][0][0]}")
+
+        if not composed:
+            composed = [self._normalize_text(texts[0])]
+
+        truncated = ". ".join(composed[: self.max_sentences])
+        if not truncated.endswith("."):
+            truncated += "."
+        return truncated
+
+    def _embed_texts(self, texts: List[str]) -> np.ndarray:
+        tfidf = TfidfVectorizer(max_features=max(1024, self.encoding_dim * 8), ngram_range=(1, 2))
+        x = tfidf.fit_transform(texts)
+
+        if x.shape[1] > self.encoding_dim:
+            svd_dim = min(self.encoding_dim, x.shape[0] - 1, x.shape[1] - 1)
+            if svd_dim >= 2:
+                svd = TruncatedSVD(n_components=svd_dim, random_state=0)
+                z = svd.fit_transform(x)
+            else:
+                z = x.toarray()
+        else:
+            z = x.toarray()
+
+        # pad/crop to target dim for stable downstream shape
+        if z.shape[1] < self.encoding_dim:
+            pad = np.zeros((z.shape[0], self.encoding_dim - z.shape[1]), dtype=np.float32)
+            z = np.concatenate([z.astype(np.float32), pad], axis=1)
+        else:
+            z = z[:, : self.encoding_dim].astype(np.float32)
+
+        norm = np.linalg.norm(z, axis=1, keepdims=True)
+        z = z / np.clip(norm, 1e-12, None)
+        return z
+
+    @staticmethod
+    def _mean_pairwise_cosine(embs: np.ndarray) -> float:
+        if embs.shape[0] <= 1:
+            return 1.0
+        sim_sum, cnt = 0.0, 0
+        for i in range(embs.shape[0]):
+            for j in range(i + 1, embs.shape[0]):
+                sim_sum += float(np.dot(embs[i], embs[j]))
+                cnt += 1
+        return sim_sum / max(cnt, 1)
+
+    def build(self):
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        final_texts = {"coarse": [], "fine_src": [], "fine_tgt": []}
+        candidate_texts = {"coarse": {}, "fine_src": {}, "fine_tgt": {}}
+
+        for cls in self.classes:
+            coarse_candidates = [self._generate_coarse_once(cls, seed=k) for k in range(self.k)]
+            src_candidates = [self._generate_fine_once(cls, "src", seed=k) for k in range(self.k)]
+            tgt_candidates = [self._generate_fine_once(cls, "tgt", seed=k) for k in range(self.k)]
+
+            candidate_texts["coarse"][cls.class_id] = coarse_candidates
+            candidate_texts["fine_src"][cls.class_id] = src_candidates
+            candidate_texts["fine_tgt"][cls.class_id] = tgt_candidates
+
+            final_texts["coarse"].append(self._aggregate_candidates(coarse_candidates))
+            final_texts["fine_src"].append(self._aggregate_candidates(src_candidates))
+            final_texts["fine_tgt"].append(self._aggregate_candidates(tgt_candidates))
+
+        # embed final texts
+        all_final = final_texts["coarse"] + final_texts["fine_src"] + final_texts["fine_tgt"]
+        all_emb = self._embed_texts(all_final)
+        c = len(self.classes)
+        p_c = all_emb[:c]
+        p_f_src = all_emb[c : 2 * c]
+        p_f_tgt = all_emb[2 * c : 3 * c]
+
+        # confidence from candidate consistency
+        confidence = {"coarse": [], "fine_src": [], "fine_tgt": []}
+        for idx, cls in enumerate(self.classes):
+            for key in ["coarse", "fine_src", "fine_tgt"]:
+                cand = candidate_texts[key][cls.class_id]
+                emb = self._embed_texts(cand)
+                r = self._mean_pairwise_cosine(emb)
+                w = np.clip((r + 1.0) / 2.0, self.min_weight, 1.0)
+                confidence[key].append(float(w))
+
+        w_c = np.array(confidence["coarse"], dtype=np.float32).reshape(-1, 1)
+        w_src = np.array(confidence["fine_src"], dtype=np.float32).reshape(-1, 1)
+        w_tgt = np.array(confidence["fine_tgt"], dtype=np.float32).reshape(-1, 1)
+
+        if self.merge_mode == "weighted_mean":
+            merged = (w_c * p_c + w_src * p_f_src + w_tgt * p_f_tgt) / np.clip(w_c + w_src + w_tgt, 1e-6, None)
+        elif self.merge_mode == "coarse_only":
+            merged = p_c
+        elif self.merge_mode == "fine_src_only":
+            merged = p_f_src
+        elif self.merge_mode == "fine_tgt_only":
+            merged = p_f_tgt
+        else:
+            raise ValueError(f"Unsupported merge_mode: {self.merge_mode}")
+
+        merged = merged / np.clip(np.linalg.norm(merged, axis=1, keepdims=True), 1e-12, None)
+
+        np.save(os.path.join(self.output_dir, "semantic_bank_coarse.npy"), p_c)
+        np.save(os.path.join(self.output_dir, "semantic_bank_fine_src.npy"), p_f_src)
+        np.save(os.path.join(self.output_dir, "semantic_bank_fine_tgt.npy"), p_f_tgt)
+        np.save(os.path.join(self.output_dir, "semantic_bank_combined.npy"), merged)
+        np.save(os.path.join(self.output_dir, "semantic_weights_coarse.npy"), w_c.squeeze(1))
+        np.save(os.path.join(self.output_dir, "semantic_weights_fine_src.npy"), w_src.squeeze(1))
+        np.save(os.path.join(self.output_dir, "semantic_weights_fine_tgt.npy"), w_tgt.squeeze(1))
+
+        metadata = {
+            "dataset": self.dataset,
+            "num_classes": len(self.classes),
+            "encoding_dim": self.encoding_dim,
+            "k": self.k,
+            "rho": self.rho,
+            "merge_mode": self.merge_mode,
+            "classes": [
+                {"id": c.class_id, "name": c.name, "alias": c.alias, "definition": c.definition}
+                for c in self.classes
+            ],
+            "scene_info": self.scene_info,
+            "final_texts": final_texts,
+            "confidence": confidence,
+        }
+        with open(os.path.join(self.output_dir, "semantic_metadata.json"), "w", encoding="utf-8") as f:
+            json.dump(metadata, f, ensure_ascii=False, indent=2)
+
+        print(f"[Done] Saved semantic priors to: {self.output_dir}")
+        print("- semantic_bank_combined.npy (recommended for current training)")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Build hierarchical semantic priors for Chapter 4")
+    parser.add_argument("--config", type=str, required=True, help="YAML config path")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    with open(args.config, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    builder = SemanticPriorBuilder(cfg)
+    builder.build()
+
+
+if __name__ == "__main__":
+    main()

--- a/train.sh
+++ b/train.sh
@@ -9,12 +9,20 @@ lr=0.01 # change this to the learning rate you want to use
 # Loss weight related
 transfer_loss_weight=1 # change this to the transfer loss weight you want to use
 dis_loss_weight=1 # change this to the discriminator loss weight you want to use
+semantic_loss_weight=1 # semantic branch total weight
+
+# Semantic branch related (Chapter 4)
+use_semantic_branch=False
+semantic_path=./semantic_priors/${dataset}/semantic_bank_combined.npy
+semantic_conf_threshold=0.9
+semantic_src_weight=1.0
+semantic_tgt_weight=1.0
 
 # Others
 seed=1234 # change this to the seed you want to use
 patch_size=5 # change this to the patch size you want to use
 
 # Output related
-output=./log/${dataset}_${seed}_${lr}_${transfer_loss_weight}_${dis_loss_weight}_${patch_size}
+output=./log/${dataset}_${seed}_${lr}_${transfer_loss_weight}_${dis_loss_weight}_${semantic_loss_weight}_${patch_size}
 
-python main.py --config param.yaml --data_dir $data_dir --num_bands $num_bands --seed $seed --lr $lr --dis_loss_weight $dis_loss_weight --transfer_loss_weight $transfer_loss_weight --patch_size ${patch_size}| tee ${output}.log
+python main.py --config param.yaml --data_dir $data_dir --num_bands $num_bands --seed $seed --lr $lr --dis_loss_weight $dis_loss_weight --transfer_loss_weight $transfer_loss_weight --patch_size ${patch_size} --use_semantic_branch $use_semantic_branch --semantic_path $semantic_path --semantic_conf_threshold $semantic_conf_threshold --semantic_loss_weight $semantic_loss_weight --semantic_src_weight $semantic_src_weight --semantic_tgt_weight $semantic_tgt_weight | tee ${output}.log


### PR DESCRIPTION
### Motivation
- Add an optional semantic-prior branch to support Chapter 4 experiments that incorporate class-level semantic priors into training and aligning source/target domains. 
- Provide reusable utilities to build, load, normalize and use semantic prototype banks from templates, OpenAI-compatible LLM outputs, or manual text descriptions. 
- Make the training and model code robust to common HSI labeling conventions (background class handling) and provide CLI/config knobs to enable/disable the semantic branch. 

### Description
- Added a semantic pipeline including loader, modules, losses and builders: new files `semantic_loader.py`, `semantic_modules.py`, `semantic_losses.py`, `semantic_priors/scripts/build_semantic_priors.py`, and `semantic_priors/scripts/build_manual_semantic_bank.py` to construct, encode and load semantic banks. 
- Extended the model with an optional semantic branch: `models.NewTransferNet` now accepts semantic-related args, registers a `semantic_bank` buffer, projects visual and semantic embeddings via `ProjectionHead`, and computes source alignment and target consistency losses (`_semantic_forward`). 
- Integrated semantic branch into training and CLI: added parser args in `main.py`, wired semantic losses into `forward`/`train` flows, improved per-class accuracy calculation to be robust to empty classes, and extended `param.yaml` and `train.sh` with semantic configuration and invocation. 
- Documentation and examples: updated `README.md`, added `docs/semantic_priors.md`, `semantic_priors/README.md`, and example YAMLs (`houston_semantic_builder.yaml`, `pavia_manual_semantics.yaml`) with usage and file format expectations. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6e6280248322a90673ecf6ff893a)