### PR TITLE
Disable semantic branch when its effective loss contribution is zero

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,6 +98,18 @@ def load_data(args):
     return source_loader, target_train_loader, target_test_loader, n_class
 
 def get_model(args):
+    # If semantic branch contributes zero to total objective, fully disable it to
+    # avoid unnecessary graph construction / optimizer param groups.
+    semantic_branch_active = args.use_semantic_branch and (
+        args.semantic_loss_weight > 0 and (args.semantic_src_weight > 0 or args.semantic_tgt_weight > 0)
+    )
+
+    if args.use_semantic_branch and not semantic_branch_active:
+        print(
+            '[semantic] semantic branch is requested but total semantic objective is zero; '
+            'disabling semantic branch for this run.'
+        )
+
     model = models.NewTransferNet(
         args.n_class,
         transfer_loss=args.transfer_loss,
@@ -105,7 +117,7 @@ def get_model(args):
         max_iter=args.max_iter,
         input_channels=args.num_bands,
         use_bottleneck=args.use_bottleneck,
-        use_semantic_branch=args.use_semantic_branch,
+        use_semantic_branch=semantic_branch_active,
         semantic_path=args.semantic_path,
         semantic_dim=args.semantic_dim,
         shared_dim=args.shared_dim,
@@ -227,7 +239,7 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
             clf_loss, dis_loss, transfer_loss, semantic_metrics = model(data_source, data_target, label_source, epoch=e)
             sem_loss = semantic_metrics['sem_loss']
             loss = clf_loss + args.transfer_loss_weight * transfer_loss + args.dis_loss_weight * dis_loss
-            if args.use_semantic_branch:
+            if model.use_semantic_branch:
                 loss = loss + args.semantic_loss_weight * sem_loss
 
             optimizer.zero_grad()


### PR DESCRIPTION
### Motivation
- Users observed large performance drops when `use_semantic_branch=True` but semantic loss weights were zero, indicating the semantic branch still affected training despite contributing no objective.
- The change aims to make the zero-contribution case behave identically to disabling the branch to avoid extra graph/parameter registration and unintended training differences.

### Description
- Add an activation gate `semantic_branch_active` in `get_model` that enables the semantic branch only when `args.use_semantic_branch` is true and the effective objective (`semantic_loss_weight` and at least one of `semantic_src_weight`/`semantic_tgt_weight`) is positive.
- Pass `use_semantic_branch=semantic_branch_active` into `NewTransferNet` and emit a runtime message when the CLI requested the branch but it is disabled due to zero objective.
- In the training loop, change the semantic-loss accumulation guard to check `model.use_semantic_branch` (the model's runtime state) instead of the raw CLI flag `args.use_semantic_branch`.

### Testing
- Ran `python -m py_compile main.py models.py semantic_losses.py semantic_loader.py semantic_modules.py`, which succeeded.
- Attempted a lightweight runtime instantiation to verify `get_model` behavior, but it failed in this environment with `ModuleNotFoundError: No module named 'torch'` due to missing dependency; this is an environment limitation rather than a code error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd341daac8322b3d0420c655e4a9e)