### PR TITLE
Semantic branch: add logit scale, auto-disable when inactive, and label-prototype checks

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,6 +67,7 @@ def get_parser():
     parser.add_argument('--semantic_hidden_dim', type=int, default=0)
     parser.add_argument('--semantic_conf_threshold', type=float, default=0.9)
     parser.add_argument('--semantic_metric', type=str, default='cosine')
+    parser.add_argument('--semantic_logit_scale', type=float, default=16.0)
     parser.add_argument('--semantic_normalize', type=str2bool, default=True)
     parser.add_argument('--semantic_loss_weight', type=float, default=1.0)
     parser.add_argument('--semantic_src_weight', type=float, default=1.0)
@@ -98,6 +99,18 @@ def load_data(args):
     return source_loader, target_train_loader, target_test_loader, n_class
 
 def get_model(args):
+    # If semantic branch contributes zero to total objective, fully disable it to
+    # avoid unnecessary graph construction / optimizer param groups.
+    semantic_branch_active = args.use_semantic_branch and (
+        args.semantic_loss_weight > 0 and (args.semantic_src_weight > 0 or args.semantic_tgt_weight > 0)
+    )
+
+    if args.use_semantic_branch and not semantic_branch_active:
+        print(
+            '[semantic] semantic branch is requested but total semantic objective is zero; '
+            'disabling semantic branch for this run.'
+        )
+
     model = models.NewTransferNet(
         args.n_class,
         transfer_loss=args.transfer_loss,
@@ -105,13 +118,14 @@ def get_model(args):
         max_iter=args.max_iter,
         input_channels=args.num_bands,
         use_bottleneck=args.use_bottleneck,
-        use_semantic_branch=args.use_semantic_branch,
+        use_semantic_branch=semantic_branch_active,
         semantic_path=args.semantic_path,
         semantic_dim=args.semantic_dim,
         shared_dim=args.shared_dim,
         semantic_hidden_dim=args.semantic_hidden_dim,
         semantic_conf_threshold=args.semantic_conf_threshold,
         semantic_metric=args.semantic_metric,
+        semantic_logit_scale=args.semantic_logit_scale,
         semantic_normalize=args.semantic_normalize,
         semantic_src_weight=args.semantic_src_weight,
         semantic_tgt_weight=args.semantic_tgt_weight,
@@ -227,7 +241,7 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
             clf_loss, dis_loss, transfer_loss, semantic_metrics = model(data_source, data_target, label_source, epoch=e)
             sem_loss = semantic_metrics['sem_loss']
             loss = clf_loss + args.transfer_loss_weight * transfer_loss + args.dis_loss_weight * dis_loss
-            if args.use_semantic_branch:
+            if model.use_semantic_branch:
                 loss = loss + args.semantic_loss_weight * sem_loss
 
             optimizer.zero_grad()

--- a/models.py
+++ b/models.py
@@ -25,6 +25,7 @@ class NewTransferNet(nn.Module):
         semantic_hidden_dim=0,
         semantic_conf_threshold=0.9,
         semantic_metric='cosine',
+        semantic_logit_scale=16.0,
         semantic_normalize=True,
         semantic_src_weight=1.0,
         semantic_tgt_weight=1.0,
@@ -61,6 +62,7 @@ class NewTransferNet(nn.Module):
         self.use_semantic_branch = use_semantic_branch
         self.semantic_conf_threshold = semantic_conf_threshold
         self.semantic_metric = semantic_metric
+        self.semantic_logit_scale = semantic_logit_scale
         self.semantic_src_weight = semantic_src_weight
         self.semantic_tgt_weight = semantic_tgt_weight
         self.semantic_tgt_warmup_epochs = semantic_tgt_warmup_epochs
@@ -102,18 +104,31 @@ class NewTransferNet(nn.Module):
 
         # Ignore background prototype (index 0) in semantic alignment if source labels are foreground-only (>=1)
         if source_label.min().item() >= 1 and zs.shape[0] > 1:
+            aligned_labels = source_label - 1
+            if aligned_labels.max().item() >= zs[1:].shape[0]:
+                raise ValueError(
+                    f"Source label/prototype mismatch after background shift: "
+                    f"max(label-1)={aligned_labels.max().item()}, prototypes={zs[1:].shape[0]}"
+                )
             sem_src_loss = source_semantic_alignment_loss(
                 zv_source,
-                source_label - 1,
+                aligned_labels,
                 zs[1:],
                 metric=self.semantic_metric,
+                logit_scale=self.semantic_logit_scale,
             )
         else:
+            if source_label.max().item() >= zs.shape[0]:
+                raise ValueError(
+                    f"Source label/prototype mismatch: max(label)={source_label.max().item()}, "
+                    f"prototypes={zs.shape[0]}"
+                )
             sem_src_loss = source_semantic_alignment_loss(
                 zv_source,
                 source_label,
                 zs,
                 metric=self.semantic_metric,
+                logit_scale=self.semantic_logit_scale,
             )
 
         if epoch <= self.semantic_tgt_warmup_epochs:
@@ -126,6 +141,7 @@ class NewTransferNet(nn.Module):
                 zs,
                 conf_threshold=self.semantic_conf_threshold,
                 metric=self.semantic_metric,
+                logit_scale=self.semantic_logit_scale,
             )
 
         sem_loss = self.semantic_src_weight * sem_src_loss + self.semantic_tgt_weight * sem_tgt_loss

--- a/param.yaml
+++ b/param.yaml
@@ -27,6 +27,7 @@ shared_dim: 128
 semantic_hidden_dim: 0
 semantic_conf_threshold: 0.9
 semantic_metric: cosine
+semantic_logit_scale: 16.0
 semantic_normalize: True
 semantic_loss_weight: 1.0
 semantic_src_weight: 1.0

--- a/semantic_losses.py
+++ b/semantic_losses.py
@@ -9,11 +9,12 @@ def source_semantic_alignment_loss(
     source_label: torch.Tensor,
     zs_prototypes: torch.Tensor,
     metric: str = "cosine",
+    logit_scale: float = 16.0,
 ) -> torch.Tensor:
     if metric == "cosine":
         zv = l2_normalize(zv_source)
         zs = l2_normalize(zs_prototypes)
-        logits = torch.matmul(zv, zs.t())
+        logits = logit_scale * torch.matmul(zv, zs.t())
         return F.cross_entropy(logits, source_label)
     if metric == "mse":
         target_zs = zs_prototypes[source_label]
@@ -27,6 +28,7 @@ def target_semantic_consistency_loss(
     zs_prototypes: torch.Tensor,
     conf_threshold: float = 0.9,
     metric: str = "cosine",
+    logit_scale: float = 16.0,
 ):
     probs = F.softmax(target_logits, dim=1)
     conf, pseudo = torch.max(probs, dim=1)
@@ -42,7 +44,7 @@ def target_semantic_consistency_loss(
     if metric == "cosine":
         zv = l2_normalize(zv_sel)
         zs = l2_normalize(zs_prototypes)
-        logits = torch.matmul(zv, zs.t())
+        logits = logit_scale * torch.matmul(zv, zs.t())
         loss = F.cross_entropy(logits, pseudo_sel)
     elif metric == "mse":
         target_zs = zs_prototypes[pseudo_sel]


### PR DESCRIPTION
### Motivation

- Introduce an explicit logit scaling hyperparameter to stabilize cosine-based semantic losses. 
- Avoid building the semantic branch and its optimizer params when it contributes zero to the objective to save compute and prevent unnecessary graph construction. 
- Add sanity checks for label / prototype mismatches when background-index shifting is applied to prevent silent incorrect training signals. 

### Description

- Add a new CLI/config option `--semantic_logit_scale` and `semantic_logit_scale` in `param.yaml` with default `16.0`, and thread it into the model constructor as `semantic_logit_scale` on `NewTransferNet`. 
- Store `semantic_logit_scale` on the model and pass it into `source_semantic_alignment_loss` and `target_semantic_consistency_loss`, where cosine logits are now multiplied by the scale before `cross_entropy`. 
- In `get_model` disable the semantic branch early when `use_semantic_branch` is requested but total semantic objective is zero (based on `semantic_loss_weight`, `semantic_src_weight`, and `semantic_tgt_weight`) and print a message; propagate that flag into model construction. 
- Use `model.use_semantic_branch` in training loss accumulation so the branch status reflects the actual constructed model, and add validation checks in `_semantic_forward` that raise `ValueError` on label/prototype size mismatches when shifting background indices. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd341daac8322b3d0420c655e4a9e)