### PR TITLE
Add epoch-based ramp for semantic loss with new config options

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,6 +70,8 @@ def get_parser():
     parser.add_argument('--semantic_logit_scale', type=float, default=16.0)
     parser.add_argument('--semantic_normalize', type=str2bool, default=True)
     parser.add_argument('--semantic_loss_weight', type=float, default=1.0)
+    parser.add_argument('--semantic_start_epoch', type=int, default=40)
+    parser.add_argument('--semantic_ramp_end_epoch', type=int, default=55)
     parser.add_argument('--semantic_src_weight', type=float, default=1.0)
     parser.add_argument('--semantic_tgt_weight', type=float, default=1.0)
     parser.add_argument('--semantic_tgt_warmup_epochs', type=int, default=0)
@@ -200,6 +202,13 @@ def test(model, target_test_loader, args):
     return acc, test_loss.avg, per_class_acc, oa, aa, kappa, all_features, all_targets
 
 def train(source_loader, target_train_loader, target_test_loader, model, optimizer, lr_scheduler, args):
+    def get_semantic_weight(epoch, lambda_sem_max, start_epoch, ramp_end_epoch):
+        if epoch < start_epoch:
+            return 0.0
+        if epoch < ramp_end_epoch:
+            return lambda_sem_max * (epoch - start_epoch) / float(ramp_end_epoch - start_epoch)
+        return lambda_sem_max
+
     start_time = time.time()
     len_source_loader = len(source_loader)
     len_target_loader = len(target_train_loader)
@@ -248,7 +257,14 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
             iter_source, iter_target = iter(source_loader), iter(target_train_loader)
 
         criterion = torch.nn.CrossEntropyLoss()
-        for _ in range(n_batch):
+        lambda_sem = get_semantic_weight(
+            e,
+            args.semantic_loss_weight,
+            args.semantic_start_epoch,
+            args.semantic_ramp_end_epoch,
+        )
+
+        for batch_idx in range(n_batch):
             data_source, label_source = next(iter_source) # .next()
             data_target, target_label_unused = next(iter_target) # .next()
             data_source, label_source = data_source.to(
@@ -256,13 +272,14 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
             data_target = data_target.to(args.device)
 
             clf_loss, dis_loss, transfer_loss, semantic_metrics = model(data_source, data_target, label_source, epoch=e)
-            sem_loss = semantic_metrics['sem_loss']
+            sem_loss_raw = semantic_metrics['sem_loss']
+            sem_loss = lambda_sem * sem_loss_raw
             if model.use_semantic_branch and batch_idx == 0 and args.debug_semantic:
                 print(f"[semantic][epoch {e}] src coarse logits shape: {semantic_metrics['source_coarse_sem_logits_shape']}")
                 print(f"[semantic][epoch {e}] src fine logits shape: {semantic_metrics['source_fine_sem_logits_shape']}")
             loss = clf_loss + args.transfer_loss_weight * transfer_loss + args.dis_loss_weight * dis_loss
             if model.use_semantic_branch:
-                loss = loss + args.semantic_loss_weight * sem_loss
+                loss = loss + sem_loss
 
             optimizer.zero_grad()
             loss.backward()

--- a/param.yaml
+++ b/param.yaml
@@ -30,6 +30,8 @@ semantic_metric: cosine
 semantic_logit_scale: 8
 semantic_normalize: True
 semantic_loss_weight: 0.02
+semantic_start_epoch: 40
+semantic_ramp_end_epoch: 55
 semantic_src_weight: 1.0
 semantic_tgt_weight: 0.1
 


### PR DESCRIPTION
### Motivation
- Introduce a controllable, epoch-based ramp-up for the semantic branch loss so the semantic objective can start later and increase smoothly during training.
- Expose ramp scheduling parameters in configuration so different curricula can be experimented with without code changes.

### Description
- Add two new CLI arguments `--semantic_start_epoch` and `--semantic_ramp_end_epoch` in `get_parser()` and corresponding keys in `param.yaml` to configure when the semantic loss begins and when it reaches full weight.
- Implement `get_semantic_weight(epoch, lambda_sem_max, start_epoch, ramp_end_epoch)` inside `train()` to compute a per-epoch multiplier that is `0` before `start_epoch`, linearly ramps up until `ramp_end_epoch`, and equals `lambda_sem_max` afterward.
- Compute `lambda_sem` each epoch and apply it to the raw semantic loss (`semantic_metrics['sem_loss']`) before adding to the total loss, replacing the previous direct multiplication by `args.semantic_loss_weight`.
- Change the training inner loop to `for batch_idx in range(n_batch):` to support per-batch debug logging and conditional printing of semantic debug information.

### Testing
- No automated tests were added or modified for this change.
- No test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11450c25c8322bc5995f91e422fb9)