### PR TITLE
Delay semantic branch optimization until ramp start

### DIFF
--- a/main.py
+++ b/main.py
@@ -205,6 +205,8 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
     def get_semantic_weight(epoch, lambda_sem_max, start_epoch, ramp_end_epoch):
         if epoch < start_epoch:
             return 0.0
+        if ramp_end_epoch <= start_epoch:
+            return lambda_sem_max
         if epoch < ramp_end_epoch:
             return lambda_sem_max * (epoch - start_epoch) / float(ramp_end_epoch - start_epoch)
         return lambda_sem_max
@@ -263,6 +265,7 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
             args.semantic_start_epoch,
             args.semantic_ramp_end_epoch,
         )
+        semantic_enabled = model.use_semantic_branch and (lambda_sem > 0)
 
         for batch_idx in range(n_batch):
             data_source, label_source = next(iter_source) # .next()
@@ -271,7 +274,13 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
                 args.device), label_source.to(args.device)
             data_target = data_target.to(args.device)
 
-            clf_loss, dis_loss, transfer_loss, semantic_metrics = model(data_source, data_target, label_source, epoch=e)
+            clf_loss, dis_loss, transfer_loss, semantic_metrics = model(
+                data_source,
+                data_target,
+                label_source,
+                epoch=e,
+                semantic_enabled=semantic_enabled,
+            )
             sem_loss_raw = semantic_metrics['sem_loss']
             sem_loss = lambda_sem * sem_loss_raw
             if model.use_semantic_branch and batch_idx == 0 and args.debug_semantic:
@@ -320,8 +329,8 @@ def train(source_loader, target_train_loader, target_test_loader, model, optimiz
             train_loss_total.avg,
         ])
 
-        info = 'Epoch: [{:2d}/{}], cls_loss: {:.4f}, transfer_loss: {:.4f}, dis_loss: {:.4f}, sem_loss: {:.4f}, sem_src: {:.4f}, sem_tgt: {:.4f}, sem_ratio: {:.4f}, sem_conf: {:.4f}, sem_margin: {:.4f}, sem_src_coarse: {:.4f}, sem_src_fine: {:.4f}, lambda_sem_t: {:.4f}, lambda_sem_tgt: {:.4f}, total_Loss: {:.4f}'.format(
-            e, args.n_epoch, train_loss_clf.avg, train_loss_transfer.avg, train_loss_dis.avg, train_loss_sem.avg, train_loss_sem_src.avg, train_loss_sem_tgt.avg, train_sem_valid_ratio.avg, train_sem_conf_ratio.avg, train_sem_margin_ratio.avg, train_sem_src_coarse.avg, train_sem_src_fine.avg, train_lambda_sem.avg, train_lambda_sem_tgt.avg, train_loss_total.avg)
+        info = 'Epoch: [{:2d}/{}], cls_loss: {:.4f}, transfer_loss: {:.4f}, dis_loss: {:.4f}, sem_loss: {:.4f}, sem_src: {:.4f}, sem_tgt: {:.4f}, sem_ratio: {:.4f}, sem_conf: {:.4f}, sem_margin: {:.4f}, sem_src_coarse: {:.4f}, sem_src_fine: {:.4f}, lambda_sem: {:.4f}, lambda_sem_t: {:.4f}, lambda_sem_tgt: {:.4f}, total_Loss: {:.4f}'.format(
+            e, args.n_epoch, train_loss_clf.avg, train_loss_transfer.avg, train_loss_dis.avg, train_loss_sem.avg, train_loss_sem_src.avg, train_loss_sem_tgt.avg, train_sem_valid_ratio.avg, train_sem_conf_ratio.avg, train_sem_margin_ratio.avg, train_sem_src_coarse.avg, train_sem_src_fine.avg, lambda_sem, train_lambda_sem.avg, train_lambda_sem_tgt.avg, train_loss_total.avg)
         # Test
         stop += 1
         test_acc, test_loss, per_class_acc, oa, aa, kappa, all_features, all_targets = test(model, target_test_loader, args)

--- a/models.py
+++ b/models.py
@@ -129,7 +129,7 @@ class NewTransferNet(nn.Module):
         progress = min(max((epoch - self.semantic_tgt_warmup_epochs) / remain, 0.0), 1.0)
         return progress ** self.semantic_tgt_ramp_power
 
-    def _semantic_forward(self, source_feat, target_feat, source_label, target_clf, epoch=1):
+    def _semantic_forward(self, source_feat, target_feat, source_label, target_clf, epoch=1, semantic_enabled=True):
         zero = torch.tensor(0.0, device=source_feat.device)
         metrics = {
             'sem_loss': zero,
@@ -145,7 +145,7 @@ class NewTransferNet(nn.Module):
             'source_coarse_sem_logits_shape': 'N/A',
             'source_fine_sem_logits_shape': 'N/A',
         }
-        if not self.use_semantic_branch:
+        if (not self.use_semantic_branch) or (not semantic_enabled):
             return metrics
 
         main_source_feat = source_feat
@@ -242,7 +242,7 @@ class NewTransferNet(nn.Module):
 
         return metrics
 
-    def forward(self, source, target, source_label, epoch=1):
+    def forward(self, source, target, source_label, epoch=1, semantic_enabled=True):
         source_outputs, \
         source_x_IN_1, source_x_1, source_x_style_1a, \
         source_x_IN_2, source_x_2, source_x_style_2a, \
@@ -300,7 +300,14 @@ class NewTransferNet(nn.Module):
 
         transfer_target = target_prob if self.transfer_loss == 'bnm' else target_feat
         transfer_loss = self.adapt_loss(source_feat, transfer_target, **kwargs)
-        semantic_metrics = self._semantic_forward(source_feat, target_feat, source_label, target_clf, epoch=epoch)
+        semantic_metrics = self._semantic_forward(
+            source_feat,
+            target_feat,
+            source_label,
+            target_clf,
+            epoch=epoch,
+            semantic_enabled=semantic_enabled,
+        )
 
         return clf_loss, dis_loss, transfer_loss, semantic_metrics
 


### PR DESCRIPTION
### Motivation
- Ensure the semantic branch is truly inactive in early training so it does not perform forward/metric work when its external weight is 0. 
- Avoid runtime issues from the ramp schedule (division-by-zero) when `semantic_ramp_end_epoch <= semantic_start_epoch`. 
- Keep the training code and logs consistent by returning safe zero/default semantic metrics when the branch is disabled. 

### Description
- Modified `train()` in `main.py` to add a safe guard in `get_semantic_weight()` so that when `ramp_end_epoch <= start_epoch` the function returns `lambda_sem_max` instead of dividing by zero. 
- In `train()` compute `semantic_enabled = model.use_semantic_branch and (lambda_sem > 0)` and pass `semantic_enabled` to the model forward to ensure the model also disables internal semantic computations while external weight is 0. 
- Extended `NewTransferNet.forward()` and `_semantic_forward()` in `models.py` to accept an explicit `semantic_enabled` argument and short-circuit to return a metrics dict of zero/safe defaults when `semantic_enabled` is False or `self.use_semantic_branch` is False. 
- Kept the returned `semantic_metrics` keys compatible with existing training logging (`sem_loss`, `sem_src_loss`, `sem_tgt_loss`, `sem_valid_ratio`, `sem_conf_pass_ratio`, `sem_margin_pass_ratio`, `sem_src_coarse_loss`, `sem_src_fine_loss`, `lambda_sem_t`, `lambda_sem_tgt`, etc.), and added the external `lambda_sem` value to the epoch log output without changing other training/test/optimizer/early-stop logic. 

### Testing
- Ran syntax/byte-compile check with `python -m py_compile main.py models.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11b49be1c8322b75d3324336f825c)